### PR TITLE
Implemented the pending, completed and failed transitions

### DIFF
--- a/service/controller/resource/etcdbackup/cleanup.go
+++ b/service/controller/resource/etcdbackup/cleanup.go
@@ -1,0 +1,28 @@
+package etcdbackup
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/backup/v1alpha1"
+	"github.com/giantswarm/microerror"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (r *Resource) cleanup(ctx context.Context, etcdBackup v1alpha1.ETCDBackup) error {
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Looking for completed ETCDBackup resources older than %d seconds", CRKeepTimeoutSeconds))
+	diff := time.Now().UTC().Sub(etcdBackup.Status.FinishedTimestamp.Time).Seconds()
+	if diff > CRKeepTimeoutSeconds {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Deleting (state %s, %f seconds old)", etcdBackup.Status.Status, diff))
+		err := r.k8sClient.G8sClient().BackupV1alpha1().ETCDBackups().Delete(etcdBackup.Name, &v1.DeleteOptions{})
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Not due for deletion (state %s, %f seconds old)", etcdBackup.Status.Status, diff))
+	}
+
+	return nil
+}

--- a/service/controller/resource/etcdbackup/create.go
+++ b/service/controller/resource/etcdbackup/create.go
@@ -17,6 +17,9 @@ const (
 	GlobalBackupStateRunning   = "Running"
 	GlobalBackupStateCompleted = "Completed"
 	GlobalBackupSateFailed     = "Failed"
+
+	// Default values
+	CRKeepTimeoutSeconds = 7 * 24 * 60 * 60
 )
 
 // configureStateMachine configures and returns state machine that is driven by

--- a/service/controller/resource/etcdbackup/create_completed.go
+++ b/service/controller/resource/etcdbackup/create_completed.go
@@ -3,9 +3,23 @@ package etcdbackup
 import (
 	"context"
 
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/etcd-backup-operator/service/controller/key"
 	"github.com/giantswarm/etcd-backup-operator/service/controller/resource/etcdbackup/internal/state"
 )
 
+// Deletes the ETCDBackup if it's older than the threshold.
 func (r *Resource) globalBackupCompletedTransition(ctx context.Context, obj interface{}, currentState state.State) (state.State, error) {
-	return "", nil
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	err = r.cleanup(ctx, customObject)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return GlobalBackupStateCompleted, nil
 }

--- a/service/controller/resource/etcdbackup/create_failed.go
+++ b/service/controller/resource/etcdbackup/create_failed.go
@@ -3,9 +3,23 @@ package etcdbackup
 import (
 	"context"
 
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/etcd-backup-operator/service/controller/key"
 	"github.com/giantswarm/etcd-backup-operator/service/controller/resource/etcdbackup/internal/state"
 )
 
+// Deletes the ETCDBackup if it's older than the threshold.
 func (r *Resource) globalBackupFailedTransition(ctx context.Context, obj interface{}, currentState state.State) (state.State, error) {
-	return "", nil
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	err = r.cleanup(ctx, customObject)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return GlobalBackupSateFailed, nil
 }

--- a/service/controller/resource/etcdbackup/create_pending.go
+++ b/service/controller/resource/etcdbackup/create_pending.go
@@ -2,10 +2,37 @@ package etcdbackup
 
 import (
 	"context"
+	"time"
 
+	"github.com/giantswarm/apiextensions/pkg/apis/backup/v1alpha1"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/etcd-backup-operator/service/controller/key"
 	"github.com/giantswarm/etcd-backup-operator/service/controller/resource/etcdbackup/internal/state"
 )
 
+// Sets the StartedTimestamp for the global reconciliation and initializes the Status->Instances field.
+// Then, it moves to the Running stage.
 func (r *Resource) globalBackupPendingTransition(ctx context.Context, obj interface{}, currentState state.State) (state.State, error) {
-	return GlobalBackupStatePending, nil
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "Initializing global Status")
+	customObject.Status.StartedTimestamp = v1alpha1.DeepCopyTime{
+		Time: time.Now().UTC(),
+	}
+	customObject.Status.Instances = []v1alpha1.ETCDInstanceBackupStatus{}
+
+	err = r.persistCustomObject(customObject)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "Initialized global Status")
+
+	// No need to cancel the reconciliation: the state is changing so this will be done in EnsureCreated.
+
+	return GlobalBackupStateRunning, nil
 }

--- a/service/controller/resource/etcdbackup/status.go
+++ b/service/controller/resource/etcdbackup/status.go
@@ -12,6 +12,10 @@ func (r *Resource) getGlobalStatus(customObject backupv1alpha1.ETCDBackup) (stri
 func (r *Resource) setGlobalStatus(customObject backupv1alpha1.ETCDBackup, updatedStatus string) error {
 	customObject.Status.Status = updatedStatus
 
+	return r.persistCustomObject(customObject)
+}
+
+func (r *Resource) persistCustomObject(customObject backupv1alpha1.ETCDBackup) error {
 	_, err := r.k8sClient.G8sClient().BackupV1alpha1().ETCDBackups().UpdateStatus(&customObject)
 	if err != nil {
 		return microerror.Mask(err)


### PR DESCRIPTION
Issue: https://github.com/giantswarm/giantswarm/issues/5297

Another part of the implementation of the new etcd-backup-operator.
This time it is the reconciliation loop (state transitions).