### PR TITLE
Avoid exporting metrics for delete clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.3] 2020-05-22
+## [1.0.4] 2020-05-22
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Avoid exporting metrics for deleted clusters.
+
+## [1.0.3] 2020-05-22
+
+### Fixed
+
 - Fixed prometheus exporter.
 
 ## [1.0.2] 2020-05-22
@@ -31,7 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - First release.
 
-[Unreleased]: https://github.com/giantswarm/etcd-backup-operator/compare/v1.0.3...HEAD
+[Unreleased]: https://github.com/giantswarm/etcd-backup-operator/compare/v1.0.4...HEAD
+[1.0.4]: https://github.com/giantswarm/etcd-backup-operator/compare/v1.0.3...1.0.4
 [1.0.3]: https://github.com/giantswarm/etcd-backup-operator/compare/v1.0.2...1.0.3
 [1.0.2]: https://github.com/giantswarm/etcd-backup-operator/compare/v1.0.1...1.0.2
 [1.0.1]: https://github.com/giantswarm/etcd-backup-operator/compare/v1.0.0...1.0.1

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA      = "n/a"
 	name        = "etcd-backup-operator"
 	source      = "https://github.com/giantswarm/etcd-backup-operator"
-	version     = "1.0.4-dev"
+	version     = "1.0.4"
 )
 
 func Description() string {


### PR DESCRIPTION
this PR stops exporting metric data for deleted clusters