### PR TITLE
Add support for HA masters clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add monitoring labels
 
+### Changed
+
+- Use a different secret to get ETCD data from because the previous approach wasn't working for HA masters clusters.
+
 ## [1.1.0] 2020-08-21
 
 ### Added

--- a/pkg/giantnetes/utils.go
+++ b/pkg/giantnetes/utils.go
@@ -136,7 +136,7 @@ func (u *Utils) checkClusterVersionSupport(cluster clusterWithProvider) (bool, e
 func (u *Utils) getEtcdTLSCfg(clusterID string) (*TLSClientConfig, error) {
 	k8sClient := u.K8sClient.K8sClient()
 	getOpts := metav1.GetOptions{}
-	secret, err := k8sClient.CoreV1().Secrets(secretNamespace).Get(fmt.Sprintf("%s-etcd", clusterID), getOpts)
+	secret, err := k8sClient.CoreV1().Secrets(secretNamespace).Get(fmt.Sprintf("%s-calico-etcd-client", clusterID), getOpts)
 	if err != nil {
 		return nil, microerror.Maskf(executionFailedError, "error getting etcd client certificates for guest cluster %#q with error %#q", clusterID, err)
 	}


### PR DESCRIPTION
This operator was using a secret called `<cluster-id>-etcd` to get the needed information to connect to the ETCD instance to backup.
That secret doesn't exist on HA masters clusters, that were not backupped for this reason.

This PR aims at solving the above issue by using a different secret name.