### PR TITLE
Add support for 13.0.0 azure clusters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add support for 13.0.0 azure clusters.
+
 ## [2.0.0] - 2020-09-23
 
-## Changed
+### Changed
 
 - Updated backward incompatible Kubernetes dependencies to v1.18.5.
 


### PR DESCRIPTION
This projects relies on the `Spec.VersionBundle.Version` of `AzureConfig` to get the cluster release and decide if the cluster has to be backed up or not.
That field is not populated for 13.0.0 clusters and we need to rely on the CR labels.
This lead to clusters not being backed up.

This PR aims at solving that issue.