### PR TITLE
Disable v2 backup for aws and azure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Disabled etcd v2 backup for Azure and AWS.
+
 ## [2.2.1] - 2021-04-06
 
 - Bump up dependencies:

--- a/helm/etcd-backup-operator/ci/default-values.yaml
+++ b/helm/etcd-backup-operator/ci/default-values.yaml
@@ -5,6 +5,8 @@ Installation:
       EtcdBackup:
         EtcdDataDir: ""
       TestingEnvironment: ""
+    Provider:
+      Kind: AWS
     Secret:
       EtcdBackup:
         AWSAccessKey: ""

--- a/helm/etcd-backup-operator/templates/configmap.yaml
+++ b/helm/etcd-backup-operator/templates/configmap.yaml
@@ -25,7 +25,7 @@ data:
         bucket: "{{ .Values.Installation.V1.Infra.EtcdBackup.S3Bucket }}"
         region: "{{ .Values.Installation.V1.Infra.EtcdBackup.S3Region }}"
       etcdv2:
-        datadir: {{ if eq .Values.Installation.V1.Provider.Kind "kvm" }}/var/lib/etcd{{ end }}
+        datadir: "{{ if eq .Values.Installation.V1.Provider.Kind "kvm" }}/var/lib/etcd{{ end }}"
       etcdv3:
         cacert: "/certs/{{ .Values.Installation.V1.Infra.EtcdBackup.ClientCaCertFileName }}"
         cert: "/certs/{{ .Values.Installation.V1.Infra.EtcdBackup.ClientCertFileName }}"

--- a/helm/etcd-backup-operator/templates/configmap.yaml
+++ b/helm/etcd-backup-operator/templates/configmap.yaml
@@ -25,7 +25,7 @@ data:
         bucket: "{{ .Values.Installation.V1.Infra.EtcdBackup.S3Bucket }}"
         region: "{{ .Values.Installation.V1.Infra.EtcdBackup.S3Region }}"
       etcdv2:
-        datadir: /var/lib/etcd
+        datadir: {{ if eq .Values.Installation.V1.Provider.Kind "kvm" }}/var/lib/etcd{{ end }}
       etcdv3:
         cacert: "/certs/{{ .Values.Installation.V1.Infra.EtcdBackup.ClientCaCertFileName }}"
         cert: "/certs/{{ .Values.Installation.V1.Infra.EtcdBackup.ClientCertFileName }}"


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/18112

etcd v2 is not used on azure and aws, this PR removes etcd v2 backups for aws and azure installations