### PR TITLE
Change cronjob api version for k8s 1.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Cronjob template now uses apiVersion `batch/v1` which is default in k8s 1.21 
+
 ## [2.3.0] - 2021-07-19
 
 ### Changed

--- a/helm/etcd-backup-operator/Chart.yaml
+++ b/helm/etcd-backup-operator/Chart.yaml
@@ -4,5 +4,6 @@ description: "Helm chart for etcd-backup-operator."
 home: "https://github.com/giantswarm/etcd-backup-operator"
 version: "[[ .Version ]]"
 appVersion: "[[ .AppVersion ]]"
+kubeVersion: ">=1.21.0-0"
 annotations:
   application.giantswarm.io/team: "celestial"

--- a/helm/etcd-backup-operator/Chart.yaml
+++ b/helm/etcd-backup-operator/Chart.yaml
@@ -4,6 +4,6 @@ description: "Helm chart for etcd-backup-operator."
 home: "https://github.com/giantswarm/etcd-backup-operator"
 version: "[[ .Version ]]"
 appVersion: "[[ .AppVersion ]]"
-kubeVersion: ">=1.21.0-0"
+kubeVersion: ">=1.21.0"
 annotations:
   application.giantswarm.io/team: "celestial"

--- a/helm/etcd-backup-operator/templates/cronjob.yaml
+++ b/helm/etcd-backup-operator/templates/cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v2alpha1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "resource.default.name" . }}-scheduler


### PR DESCRIPTION
`batch/v2alpha1` has been removed in k8s 1.21 it is now `batch/v1` 
related to https://github.com/giantswarm/giantswarm/issues/18272