### PR TITLE
Change cronjob template apiversion to v2beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Changed cronjob template apiVersion to `v2beta1`
+
 ## [2.4.0] - 2021-08-05
 
 ### Changed

--- a/helm/etcd-backup-operator/templates/cronjob.yaml
+++ b/helm/etcd-backup-operator/templates/cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v2alpha1
+apiVersion: batch/v2beta1
 kind: CronJob
 metadata:
   name: {{ include "resource.default.name" . }}-scheduler


### PR DESCRIPTION
`batch/v2alpha1` has been removed in k8s 1.21 it is now `batch/v1` as GA.

This changes the apiVersion to `v2beta1` for the transition period.

related to giantswarm/giantswarm#18272