### PR TITLE
Use a clearer naming schema for backup files.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,19 @@ workflows:
 
       - architect/push-to-docker:
           context: "architect"
+          name: push-etcd-backup-operator-to-docker
+          image: "docker.io/giantswarm/etcd-backup-operator"
+          username_envar: "DOCKER_USERNAME"
+          password_envar: "DOCKER_PASSWORD"
+          requires:
+            - go-build-etcd-backup-operator
+          filters:
+            # Trigger the job also on git tag.
+            tags:
+              only: /^v.*/
+
+      - architect/push-to-docker:
+          context: "architect"
           name: push-etcd-backup-operator-to-aliyun
           image: "registry-intl.cn-shanghai.aliyuncs.com/giantswarm/etcd-backup-operator"
           username_envar: "ALIYUN_USERNAME"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,19 +29,6 @@ workflows:
 
       - architect/push-to-docker:
           context: "architect"
-          name: push-etcd-backup-operator-to-docker
-          image: "docker.io/giantswarm/etcd-backup-operator"
-          username_envar: "DOCKER_USERNAME"
-          password_envar: "DOCKER_PASSWORD"
-          requires:
-            - go-build-etcd-backup-operator
-          filters:
-            # Trigger the job also on git tag.
-            tags:
-              only: /^v.*/
-
-      - architect/push-to-docker:
-          context: "architect"
           name: push-etcd-backup-operator-to-aliyun
           image: "registry-intl.cn-shanghai.aliyuncs.com/giantswarm/etcd-backup-operator"
           username_envar: "ALIYUN_USERNAME"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Smart apiVersion selection for cronjob.
 - Use a clearer naming schema for backup files.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Changed cronjob template apiVersion to `v2beta1`
 - Use a clearer naming schema for backup files.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Changed cronjob template apiVersion to `v2beta1`
+- Use a clearer naming schema for backup files.
 
 ### Added
 

--- a/flag/service/service.go
+++ b/flag/service/service.go
@@ -6,9 +6,10 @@ import (
 
 // Service is an intermediate data structure for command line configuration flags.
 type Service struct {
-	Kubernetes kubernetes.Kubernetes
-	S3         S3Uploader
-	ETCDv2     ETCDv2Settings
-	ETCDv3     ETCDv3Settings
-	Sentry     Sentry
+	Kubernetes       kubernetes.Kubernetes
+	S3               S3Uploader
+	ETCDv2           ETCDv2Settings
+	ETCDv3           ETCDv3Settings
+	InstallationName string
+	Sentry           Sentry
 }

--- a/flag/service/service.go
+++ b/flag/service/service.go
@@ -6,10 +6,10 @@ import (
 
 // Service is an intermediate data structure for command line configuration flags.
 type Service struct {
-	Kubernetes       kubernetes.Kubernetes
-	S3               S3Uploader
-	ETCDv2           ETCDv2Settings
-	ETCDv3           ETCDv3Settings
-	InstallationName string
-	Sentry           Sentry
+	Kubernetes   kubernetes.Kubernetes
+	S3           S3Uploader
+	ETCDv2       ETCDv2Settings
+	ETCDv3       ETCDv3Settings
+	Installation string
+	Sentry       Sentry
 }

--- a/helm/etcd-backup-operator/templates/configmap.yaml
+++ b/helm/etcd-backup-operator/templates/configmap.yaml
@@ -31,5 +31,6 @@ data:
         cert: "/certs/{{ .Values.clientCertFileName }}"
         key: "/certs/{{ .Values.clientKeyFileName }}"
         endpoints: "{{ .Values.etcdEndpoints }}"
+      installationName: "{{ .Values.installation }}"
       sentry:
         dsn: "https://4553619a49094382872ae888b7e8f7f3@o346224.ingest.sentry.io/5544797"

--- a/helm/etcd-backup-operator/templates/configmap.yaml
+++ b/helm/etcd-backup-operator/templates/configmap.yaml
@@ -31,6 +31,6 @@ data:
         cert: "/certs/{{ .Values.clientCertFileName }}"
         key: "/certs/{{ .Values.clientKeyFileName }}"
         endpoints: "{{ .Values.etcdEndpoints }}"
-      installationName: "{{ .Values.installation }}"
+      installation: "{{ .Values.installation }}"
       sentry:
         dsn: "https://4553619a49094382872ae888b7e8f7f3@o346224.ingest.sentry.io/5544797"

--- a/helm/etcd-backup-operator/templates/cronjob.yaml
+++ b/helm/etcd-backup-operator/templates/cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v2beta1
+apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: {{ include "resource.default.name" . }}-scheduler

--- a/helm/etcd-backup-operator/templates/cronjob.yaml
+++ b/helm/etcd-backup-operator/templates/cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/{{ if .Capabilities.APIVersions.Has "batch/v1" }}v1{{ else }}v1beta1{{ end }}
 kind: CronJob
 metadata:
   name: {{ include "resource.default.name" . }}-scheduler

--- a/helm/etcd-backup-operator/templates/cronjob.yaml
+++ b/helm/etcd-backup-operator/templates/cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/{{ if .Capabilities.APIVersions.Has "batch/v1" }}v1{{ else }}v1beta1{{ end }}
+apiVersion: batch/{{ if ge .Capabilities.KubeVersion.Minor 21 }}v1{{ else }}v1beta1{{ end }}
 kind: CronJob
 metadata:
   name: {{ include "resource.default.name" . }}-scheduler

--- a/helm/etcd-backup-operator/templates/cronjob.yaml
+++ b/helm/etcd-backup-operator/templates/cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/{{ if ge .Capabilities.KubeVersion.Minor 21 }}v1{{ else }}v1beta1{{ end }}
+apiVersion: batch/{{ if ge (.Capabilities.KubeVersion.Minor | int) 21 }}v1{{ else }}v1beta1{{ end }}
 kind: CronJob
 metadata:
   name: {{ include "resource.default.name" . }}-scheduler

--- a/helm/etcd-backup-operator/templates/deployment.yaml
+++ b/helm/etcd-backup-operator/templates/deployment.yaml
@@ -79,8 +79,6 @@ spec:
               secretKeyRef:
                 name: {{ include "resource.default.name" . }}
                 key: ETCDBACKUP_PASSPHRASE
-          - name: FILENAME_PREFIX
-            value: "{{ .Values.clusterPrefix }}"
         livenessProbe:
           httpGet:
             path: /healthz

--- a/helm/etcd-backup-operator/values.schema.json
+++ b/helm/etcd-backup-operator/values.schema.json
@@ -108,7 +108,7 @@
             }
         },
         "testingEnvironment": {
-            "type": "string"
+            "type": "boolean"
         }
     }
 }

--- a/helm/etcd-backup-operator/values.schema.json
+++ b/helm/etcd-backup-operator/values.schema.json
@@ -56,6 +56,9 @@
                 }
             }
         },
+        "installation": {
+            "type": "string"
+        },
         "pod": {
             "type": "object",
             "properties": {

--- a/helm/etcd-backup-operator/values.yaml
+++ b/helm/etcd-backup-operator/values.yaml
@@ -13,7 +13,7 @@ project:
 registry:
   domain: docker.io
 
-testingEnvironment: ""
+testingEnvironment: false
 provider:
   kind: ""
 

--- a/helm/etcd-backup-operator/values.yaml
+++ b/helm/etcd-backup-operator/values.yaml
@@ -24,10 +24,11 @@ aws:
     awsAccessKey: ""
     awsSecretKey: ""
 
-clusterPrefix: ""
 etcdDataDir: ""
 clientCertsDir: "/etc/kubernetes/ssl/etcd/"
 clientCaCertFileName: ""
 clientCertFileName: ""
 clientKeyFileName: ""
 etcdEndpoints: "https://127.0.0.1:2379"
+
+installation: ""

--- a/main.go
+++ b/main.go
@@ -114,6 +114,7 @@ func mainE(ctx context.Context) error {
 	daemonCommand.PersistentFlags().String(f.Service.ETCDv3.CaCert, "", "Client CA certificate for ETCD v3 connection")
 	daemonCommand.PersistentFlags().String(f.Service.ETCDv3.Key, "", "Client private key for ETCD v3 connection")
 	daemonCommand.PersistentFlags().String(f.Service.ETCDv3.Endpoints, "", "Endpoints for ETCD v3 connection")
+	daemonCommand.PersistentFlags().String(f.Service.Installation, "", "Name of the installation")
 	daemonCommand.PersistentFlags().String(f.Service.Sentry.DSN, "", "DSN of the Sentry instance to forward errors to.")
 
 	err = newCommand.CobraCommand().Execute()

--- a/pkg/etcd/etcdv2.go
+++ b/pkg/etcd/etcdv2.go
@@ -51,7 +51,7 @@ func (b V2Backup) Cleanup() {
 // Create etcd in temporary directory, tar and compress.
 func (b V2Backup) Create() (string, error) {
 	// filename.
-	*b.filename = b.Prefix + "-etcd-etcd-v2-" + time.Now().Format(key.TsFormat)
+	*b.filename = b.Prefix + "-v2-" + time.Now().Format(key.TsFormat)
 
 	// Full path to file.
 	fpath := filepath.Join(b.getTmpDir(), *b.filename)

--- a/pkg/etcd/etcdv3.go
+++ b/pkg/etcd/etcdv3.go
@@ -57,7 +57,7 @@ func (b V3Backup) Cleanup() {
 // Create etcd in temporary directory.
 func (b V3Backup) Create() (string, error) {
 	// filename
-	*b.filename = b.Prefix + "-backup-etcd-v3-" + time.Now().Format(key.TsFormat) + key.DbExt
+	*b.filename = b.Prefix + "-v3-" + time.Now().Format(key.TsFormat) + key.DbExt
 
 	// Full path to file.
 	fpath := filepath.Join(b.getTmpDir(), *b.filename)

--- a/service/collector/etcdbackup.go
+++ b/service/collector/etcdbackup.go
@@ -125,7 +125,7 @@ func (d *ETCDBackup) Collect(ch chan<- prometheus.Metric) error {
 		return microerror.Mask(err)
 	}
 
-	tenantClusterIds = append(tenantClusterIds, key.ControlPlane)
+	tenantClusterIds = append(tenantClusterIds, key.ManagementCluster)
 
 	// Iterate over all ETCDBackup objects and select the most recent backup from each cluster.
 	latestV2SuccessMetrics := map[string]v1alpha1.ETCDInstanceBackupStatus{}

--- a/service/controller/etcd_backup.go
+++ b/service/controller/etcd_backup.go
@@ -15,14 +15,14 @@ import (
 )
 
 type ETCDBackupConfig struct {
-	K8sClient        k8sclient.Interface
-	Logger           micrologger.Logger
-	ETCDv2Settings   giantnetes.ETCDv2Settings
-	ETCDv3Settings   giantnetes.ETCDv3Settings
-	EncryptionPwd    string
-	InstallationName string
-	SentryDSN        string
-	Uploader         storage.Uploader
+	K8sClient      k8sclient.Interface
+	Logger         micrologger.Logger
+	ETCDv2Settings giantnetes.ETCDv2Settings
+	ETCDv3Settings giantnetes.ETCDv3Settings
+	EncryptionPwd  string
+	Installation   string
+	SentryDSN      string
+	Uploader       storage.Uploader
 }
 
 type ETCDBackup struct {
@@ -32,6 +32,9 @@ type ETCDBackup struct {
 func validateETCDBackupConfig(config ETCDBackupConfig) error {
 	if !config.ETCDv2Settings.AreComplete() && !config.ETCDv3Settings.AreComplete() {
 		return microerror.Maskf(invalidConfigError, "Either %T.ETCDv2Settings or %T.ETCDv3Settings must be defined", config, config)
+	}
+	if config.Installation == "" {
+		return microerror.Maskf(invalidConfigError, "%T.Installation must be defined", config)
 	}
 	if config.Uploader == nil {
 		return microerror.Maskf(invalidConfigError, "%T.Uploader must be defined", config)
@@ -87,13 +90,13 @@ func newETCDBackupResourceSets(config ETCDBackupConfig) ([]resource.Interface, e
 	var resources []resource.Interface
 	{
 		c := ETCDBackupConfig{
-			K8sClient:        config.K8sClient,
-			Logger:           config.Logger,
-			ETCDv2Settings:   config.ETCDv2Settings,
-			ETCDv3Settings:   config.ETCDv3Settings,
-			EncryptionPwd:    config.EncryptionPwd,
-			InstallationName: config.InstallationName,
-			Uploader:         config.Uploader,
+			K8sClient:      config.K8sClient,
+			Logger:         config.Logger,
+			ETCDv2Settings: config.ETCDv2Settings,
+			ETCDv3Settings: config.ETCDv3Settings,
+			EncryptionPwd:  config.EncryptionPwd,
+			Installation:   config.Installation,
+			Uploader:       config.Uploader,
 		}
 		//etcdBackupResourceSetConfig(config)
 

--- a/service/controller/etcd_backup.go
+++ b/service/controller/etcd_backup.go
@@ -15,13 +15,14 @@ import (
 )
 
 type ETCDBackupConfig struct {
-	K8sClient      k8sclient.Interface
-	Logger         micrologger.Logger
-	ETCDv2Settings giantnetes.ETCDv2Settings
-	ETCDv3Settings giantnetes.ETCDv3Settings
-	EncryptionPwd  string
-	SentryDSN      string
-	Uploader       storage.Uploader
+	K8sClient        k8sclient.Interface
+	Logger           micrologger.Logger
+	ETCDv2Settings   giantnetes.ETCDv2Settings
+	ETCDv3Settings   giantnetes.ETCDv3Settings
+	EncryptionPwd    string
+	InstallationName string
+	SentryDSN        string
+	Uploader         storage.Uploader
 }
 
 type ETCDBackup struct {
@@ -86,12 +87,13 @@ func newETCDBackupResourceSets(config ETCDBackupConfig) ([]resource.Interface, e
 	var resources []resource.Interface
 	{
 		c := ETCDBackupConfig{
-			K8sClient:      config.K8sClient,
-			Logger:         config.Logger,
-			ETCDv2Settings: config.ETCDv2Settings,
-			ETCDv3Settings: config.ETCDv3Settings,
-			EncryptionPwd:  config.EncryptionPwd,
-			Uploader:       config.Uploader,
+			K8sClient:        config.K8sClient,
+			Logger:           config.Logger,
+			ETCDv2Settings:   config.ETCDv2Settings,
+			ETCDv3Settings:   config.ETCDv3Settings,
+			EncryptionPwd:    config.EncryptionPwd,
+			InstallationName: config.InstallationName,
+			Uploader:         config.Uploader,
 		}
 		//etcdBackupResourceSetConfig(config)
 

--- a/service/controller/etcd_backup_resource_set.go
+++ b/service/controller/etcd_backup_resource_set.go
@@ -13,6 +13,9 @@ func validateETCDBackupResourceSetConfigConfig(config ETCDBackupConfig) error {
 	if !config.ETCDv2Settings.AreComplete() && !config.ETCDv3Settings.AreComplete() {
 		return microerror.Maskf(invalidConfigError, "Either %T.ETCDv2Settings or %T.ETCDv3Settings must be defined", config, config)
 	}
+	if config.InstallationName == "" {
+		return microerror.Maskf(invalidConfigError, "%T.InstallationName must be defined", config)
+	}
 	if config.Uploader == nil {
 		return microerror.Maskf(invalidConfigError, "%T.Uploader must be defined", config)
 	}
@@ -29,12 +32,13 @@ func newETCDBackupResourceSet(config ETCDBackupConfig) ([]resource.Interface, er
 	var etcdBackupResource resource.Interface
 	{
 		c := etcdbackup.Config{
-			K8sClient:      config.K8sClient,
-			Logger:         config.Logger,
-			ETCDv2Settings: config.ETCDv2Settings,
-			ETCDv3Settings: config.ETCDv3Settings,
-			EncryptionPwd:  config.EncryptionPwd,
-			Uploader:       config.Uploader,
+			K8sClient:        config.K8sClient,
+			Logger:           config.Logger,
+			ETCDv2Settings:   config.ETCDv2Settings,
+			ETCDv3Settings:   config.ETCDv3Settings,
+			EncryptionPwd:    config.EncryptionPwd,
+			InstallationName: config.InstallationName,
+			Uploader:         config.Uploader,
 		}
 
 		etcdBackupResource, err = etcdbackup.New(c)

--- a/service/controller/etcd_backup_resource_set.go
+++ b/service/controller/etcd_backup_resource_set.go
@@ -13,8 +13,8 @@ func validateETCDBackupResourceSetConfigConfig(config ETCDBackupConfig) error {
 	if !config.ETCDv2Settings.AreComplete() && !config.ETCDv3Settings.AreComplete() {
 		return microerror.Maskf(invalidConfigError, "Either %T.ETCDv2Settings or %T.ETCDv3Settings must be defined", config, config)
 	}
-	if config.InstallationName == "" {
-		return microerror.Maskf(invalidConfigError, "%T.InstallationName must be defined", config)
+	if config.Installation == "" {
+		return microerror.Maskf(invalidConfigError, "%T.Installation must be defined", config)
 	}
 	if config.Uploader == nil {
 		return microerror.Maskf(invalidConfigError, "%T.Uploader must be defined", config)
@@ -32,13 +32,13 @@ func newETCDBackupResourceSet(config ETCDBackupConfig) ([]resource.Interface, er
 	var etcdBackupResource resource.Interface
 	{
 		c := etcdbackup.Config{
-			K8sClient:        config.K8sClient,
-			Logger:           config.Logger,
-			ETCDv2Settings:   config.ETCDv2Settings,
-			ETCDv3Settings:   config.ETCDv3Settings,
-			EncryptionPwd:    config.EncryptionPwd,
-			InstallationName: config.InstallationName,
-			Uploader:         config.Uploader,
+			K8sClient:      config.K8sClient,
+			Logger:         config.Logger,
+			ETCDv2Settings: config.ETCDv2Settings,
+			ETCDv3Settings: config.ETCDv3Settings,
+			EncryptionPwd:  config.EncryptionPwd,
+			Installation:   config.Installation,
+			Uploader:       config.Uploader,
 		}
 
 		etcdBackupResource, err = etcdbackup.New(c)

--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -2,17 +2,13 @@ package key
 
 import (
 	"fmt"
-	"os"
 
 	backupv1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/backup/v1alpha1"
 	"github.com/giantswarm/microerror"
 )
 
 const (
-	ControlPlane = "Control Plane"
-
-	EnvFilenamePrefix = "FILENAME_PREFIX"
-	DefaultPrefix     = "etcd-backup"
+	ManagementCluster = "ManagementCluster"
 
 	// Environment variables.
 	EnvAWSAccessKeyID     = "AWS_ACCESS_KEY_ID"
@@ -34,14 +30,6 @@ func ToCustomObject(v interface{}) (backupv1alpha1.ETCDBackup, error) {
 	return customObject, nil
 }
 
-func FilenamePrefix(instanceName string) string {
-	globalPrefix := os.Getenv(EnvFilenamePrefix)
-	if len(globalPrefix) == 0 {
-		globalPrefix = DefaultPrefix
-	}
-
-	if instanceName == ControlPlane {
-		return globalPrefix
-	}
-	return fmt.Sprintf("%s-%s", globalPrefix, instanceName)
+func FilenamePrefix(installationName string, clusterName string) string {
+	return fmt.Sprintf("%s-%s", installationName, clusterName)
 }

--- a/service/controller/resource/etcdbackup/create_running_v2.go
+++ b/service/controller/resource/etcdbackup/create_running_v2.go
@@ -43,7 +43,7 @@ func (r *Resource) doV2Backup(ctx context.Context, etcdInstance giantnetes.ETCDI
 	if etcdSettings.AreComplete() {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Starting v2 backup on instance %s", instanceStatus.Name))
 
-		backupper := etcd.NewV2Backup(etcdInstance.ETCDv2.DataDir, r.encryptionPwd, r.logger, key.FilenamePrefix(r.installationName, instanceStatus.Name))
+		backupper := etcd.NewV2Backup(etcdInstance.ETCDv2.DataDir, r.encryptionPwd, r.logger, key.FilenamePrefix(r.installation, instanceStatus.Name))
 
 		backupAttemptResult, err := r.performBackup(ctx, backupper, instanceStatus.Name)
 		if err == nil {

--- a/service/controller/resource/etcdbackup/create_running_v2.go
+++ b/service/controller/resource/etcdbackup/create_running_v2.go
@@ -43,7 +43,7 @@ func (r *Resource) doV2Backup(ctx context.Context, etcdInstance giantnetes.ETCDI
 	if etcdSettings.AreComplete() {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Starting v2 backup on instance %s", instanceStatus.Name))
 
-		backupper := etcd.NewV2Backup(etcdInstance.ETCDv2.DataDir, r.encryptionPwd, r.logger, key.FilenamePrefix(instanceStatus.Name))
+		backupper := etcd.NewV2Backup(etcdInstance.ETCDv2.DataDir, r.encryptionPwd, r.logger, key.FilenamePrefix(r.installationName, instanceStatus.Name))
 
 		backupAttemptResult, err := r.performBackup(ctx, backupper, instanceStatus.Name)
 		if err == nil {

--- a/service/controller/resource/etcdbackup/create_running_v3.go
+++ b/service/controller/resource/etcdbackup/create_running_v3.go
@@ -44,7 +44,7 @@ func (r *Resource) doV3Backup(ctx context.Context, etcdInstance giantnetes.ETCDI
 	if etcdSettings.AreComplete() {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Starting v3 backup on instance %s", instanceStatus.Name))
 
-		backupper := etcd.NewV3Backup(etcdSettings.CaCert, etcdSettings.Cert, r.encryptionPwd, etcdSettings.Endpoints, r.logger, etcdSettings.Key, key.FilenamePrefix(r.installationName, instanceStatus.Name))
+		backupper := etcd.NewV3Backup(etcdSettings.CaCert, etcdSettings.Cert, r.encryptionPwd, etcdSettings.Endpoints, r.logger, etcdSettings.Key, key.FilenamePrefix(r.installation, instanceStatus.Name))
 
 		backupAttemptResult, err := r.performBackup(ctx, backupper, instanceStatus.Name)
 		if err == nil {

--- a/service/controller/resource/etcdbackup/create_running_v3.go
+++ b/service/controller/resource/etcdbackup/create_running_v3.go
@@ -44,7 +44,7 @@ func (r *Resource) doV3Backup(ctx context.Context, etcdInstance giantnetes.ETCDI
 	if etcdSettings.AreComplete() {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Starting v3 backup on instance %s", instanceStatus.Name))
 
-		backupper := etcd.NewV3Backup(etcdSettings.CaCert, etcdSettings.Cert, r.encryptionPwd, etcdSettings.Endpoints, r.logger, etcdSettings.Key, key.FilenamePrefix(instanceStatus.Name))
+		backupper := etcd.NewV3Backup(etcdSettings.CaCert, etcdSettings.Cert, r.encryptionPwd, etcdSettings.Endpoints, r.logger, etcdSettings.Key, key.FilenamePrefix(r.installationName, instanceStatus.Name))
 
 		backupAttemptResult, err := r.performBackup(ctx, backupper, instanceStatus.Name)
 		if err == nil {

--- a/service/controller/resource/etcdbackup/instances.go
+++ b/service/controller/resource/etcdbackup/instances.go
@@ -26,7 +26,7 @@ func (r *Resource) runBackupOnAllInstances(ctx context.Context, obj interface{},
 	// Control plane.
 	instances := []giantnetes.ETCDInstance{
 		{
-			Name:   key.ControlPlane,
+			Name:   key.ManagementCluster,
 			ETCDv2: r.etcdV2Settings,
 			ETCDv3: r.etcdV3Settings,
 		},

--- a/service/controller/resource/etcdbackup/resource.go
+++ b/service/controller/resource/etcdbackup/resource.go
@@ -15,24 +15,24 @@ const (
 )
 
 type Config struct {
-	K8sClient        k8sclient.Interface
-	Logger           micrologger.Logger
-	ETCDv2Settings   giantnetes.ETCDv2Settings
-	ETCDv3Settings   giantnetes.ETCDv3Settings
-	EncryptionPwd    string
-	InstallationName string
-	Uploader         storage.Uploader
+	K8sClient      k8sclient.Interface
+	Logger         micrologger.Logger
+	ETCDv2Settings giantnetes.ETCDv2Settings
+	ETCDv3Settings giantnetes.ETCDv3Settings
+	EncryptionPwd  string
+	Installation   string
+	Uploader       storage.Uploader
 }
 
 type Resource struct {
-	logger           micrologger.Logger
-	k8sClient        k8sclient.Interface
-	stateMachine     state.Machine
-	etcdV2Settings   giantnetes.ETCDv2Settings
-	etcdV3Settings   giantnetes.ETCDv3Settings
-	encryptionPwd    string
-	installationName string
-	uploader         storage.Uploader
+	logger         micrologger.Logger
+	k8sClient      k8sclient.Interface
+	stateMachine   state.Machine
+	etcdV2Settings giantnetes.ETCDv2Settings
+	etcdV3Settings giantnetes.ETCDv3Settings
+	encryptionPwd  string
+	installation   string
+	uploader       storage.Uploader
 }
 
 func New(config Config) (*Resource, error) {
@@ -45,21 +45,21 @@ func New(config Config) (*Resource, error) {
 	if !config.ETCDv2Settings.AreComplete() && !config.ETCDv3Settings.AreComplete() {
 		return nil, microerror.Maskf(invalidConfigError, "Either %T.ETCDv2Settings or %T.ETCDv3Settings must be defined", config, config)
 	}
-	if config.InstallationName == "" {
-		return nil, microerror.Maskf(invalidConfigError, "%T.InstallationName must not be empty", config)
+	if config.Installation == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Installation must not be empty", config)
 	}
 	if config.Uploader == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Uploader must not be empty", config)
 	}
 
 	r := &Resource{
-		logger:           config.Logger,
-		k8sClient:        config.K8sClient,
-		etcdV2Settings:   config.ETCDv2Settings,
-		etcdV3Settings:   config.ETCDv3Settings,
-		encryptionPwd:    config.EncryptionPwd,
-		installationName: config.InstallationName,
-		uploader:         config.Uploader,
+		logger:         config.Logger,
+		k8sClient:      config.K8sClient,
+		etcdV2Settings: config.ETCDv2Settings,
+		etcdV3Settings: config.ETCDv3Settings,
+		encryptionPwd:  config.EncryptionPwd,
+		installation:   config.Installation,
+		uploader:       config.Uploader,
 	}
 
 	r.configureStateMachine()

--- a/service/controller/resource/etcdbackup/resource.go
+++ b/service/controller/resource/etcdbackup/resource.go
@@ -15,22 +15,24 @@ const (
 )
 
 type Config struct {
-	K8sClient      k8sclient.Interface
-	Logger         micrologger.Logger
-	ETCDv2Settings giantnetes.ETCDv2Settings
-	ETCDv3Settings giantnetes.ETCDv3Settings
-	EncryptionPwd  string
-	Uploader       storage.Uploader
+	K8sClient        k8sclient.Interface
+	Logger           micrologger.Logger
+	ETCDv2Settings   giantnetes.ETCDv2Settings
+	ETCDv3Settings   giantnetes.ETCDv3Settings
+	EncryptionPwd    string
+	InstallationName string
+	Uploader         storage.Uploader
 }
 
 type Resource struct {
-	logger         micrologger.Logger
-	k8sClient      k8sclient.Interface
-	stateMachine   state.Machine
-	etcdV2Settings giantnetes.ETCDv2Settings
-	etcdV3Settings giantnetes.ETCDv3Settings
-	encryptionPwd  string
-	uploader       storage.Uploader
+	logger           micrologger.Logger
+	k8sClient        k8sclient.Interface
+	stateMachine     state.Machine
+	etcdV2Settings   giantnetes.ETCDv2Settings
+	etcdV3Settings   giantnetes.ETCDv3Settings
+	encryptionPwd    string
+	installationName string
+	uploader         storage.Uploader
 }
 
 func New(config Config) (*Resource, error) {
@@ -43,17 +45,21 @@ func New(config Config) (*Resource, error) {
 	if !config.ETCDv2Settings.AreComplete() && !config.ETCDv3Settings.AreComplete() {
 		return nil, microerror.Maskf(invalidConfigError, "Either %T.ETCDv2Settings or %T.ETCDv3Settings must be defined", config, config)
 	}
+	if config.InstallationName == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.InstallationName must not be empty", config)
+	}
 	if config.Uploader == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Uploader must not be empty", config)
 	}
 
 	r := &Resource{
-		logger:         config.Logger,
-		k8sClient:      config.K8sClient,
-		etcdV2Settings: config.ETCDv2Settings,
-		etcdV3Settings: config.ETCDv3Settings,
-		encryptionPwd:  config.EncryptionPwd,
-		uploader:       config.Uploader,
+		logger:           config.Logger,
+		k8sClient:        config.K8sClient,
+		etcdV2Settings:   config.ETCDv2Settings,
+		etcdV3Settings:   config.ETCDv3Settings,
+		encryptionPwd:    config.EncryptionPwd,
+		installationName: config.InstallationName,
+		uploader:         config.Uploader,
 	}
 
 	r.configureStateMachine()

--- a/service/service.go
+++ b/service/service.go
@@ -153,10 +153,10 @@ func New(config Config) (*Service, error) {
 				Key:       config.Viper.GetString(config.Flag.Service.ETCDv3.Key),
 				Cert:      config.Viper.GetString(config.Flag.Service.ETCDv3.Cert),
 			},
-			EncryptionPwd:    os.Getenv(key.EncryptionPassword),
-			InstallationName: config.Viper.GetString(config.Flag.Service.InstallationName),
-			SentryDSN:        config.Viper.GetString(config.Flag.Service.Sentry.DSN),
-			Uploader:         uploader,
+			EncryptionPwd: os.Getenv(key.EncryptionPassword),
+			Installation:  config.Viper.GetString(config.Flag.Service.Installation),
+			SentryDSN:     config.Viper.GetString(config.Flag.Service.Sentry.DSN),
+			Uploader:      uploader,
 		}
 
 		etcdBackupController, err = controller.NewETCDBackup(c)

--- a/service/service.go
+++ b/service/service.go
@@ -153,9 +153,10 @@ func New(config Config) (*Service, error) {
 				Key:       config.Viper.GetString(config.Flag.Service.ETCDv3.Key),
 				Cert:      config.Viper.GetString(config.Flag.Service.ETCDv3.Cert),
 			},
-			EncryptionPwd: os.Getenv(key.EncryptionPassword),
-			SentryDSN:     config.Viper.GetString(config.Flag.Service.Sentry.DSN),
-			Uploader:      uploader,
+			EncryptionPwd:    os.Getenv(key.EncryptionPassword),
+			InstallationName: config.Viper.GetString(config.Flag.Service.InstallationName),
+			SentryDSN:        config.Viper.GetString(config.Flag.Service.Sentry.DSN),
+			Uploader:         uploader,
 		}
 
 		etcdBackupController, err = controller.NewETCDBackup(c)


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/19809 and in order to fix https://github.com/giantswarm/roadmap/issues/512

This PR changes the naming scheme for etcd backup file to this:

`<installation name>-<cluster ID or "ManagementCluster">-<etcd version, v2 or v3>-<timestamp>`.

This makes it easy to lookup for backup files in the S3 console.