### PR TITLE
Fix cert lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix etcd certs lookup to search for secrets in all namespaces.
+
 ## [2.7.0] - 2021-11-24
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -19,8 +19,10 @@ require (
 	github.com/prometheus/client_golang v1.11.0
 	github.com/spf13/viper v1.10.1
 	golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce
+	k8s.io/api v0.18.19
 	k8s.io/apimachinery v0.18.19
 	k8s.io/client-go v0.18.19
+	sigs.k8s.io/controller-runtime v0.6.4
 )
 
 replace (


### PR DESCRIPTION
etcd backup operator looks up for etcd credentials in the default namespace for azure.
this was breaking support for clusters whose certs are in the org namespace (the default now).
this PR makes it look in all namespaces