### PR TITLE
Switch from apiextensions to apiextensions-backup for etcdbackup CRD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Switch from apiextensions to apiextensions-backup for etcdbackup CRD.
+
 ## [2.8.0] - 2022-01-21
 
 - Add possibility to backup specific clusters within an installation.

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/aws/aws-sdk-go v1.42.37
 	github.com/coreos/go-semver v0.3.0
+	github.com/giantswarm/apiextensions-backup v0.1.0
 	github.com/giantswarm/apiextensions/v3 v3.40.0
 	github.com/giantswarm/backoff v1.0.0
 	github.com/giantswarm/exporterkit v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -245,6 +245,8 @@ github.com/getsentry/sentry-go v0.11.0 h1:qro8uttJGvNAMr5CLcFI9CHR0aDzXl0Vs3Pmw/
 github.com/getsentry/sentry-go v0.11.0/go.mod h1:KBQIxiZAetw62Cj8Ri964vAEWVdgfaUCn30Q3bCvANo=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/giantswarm/apiextensions-backup v0.1.0 h1:p/9eXBNEe4WtctT4Oi3zQOZm7aNIgWRwFHBEcmsQqfQ=
+github.com/giantswarm/apiextensions-backup v0.1.0/go.mod h1:hXSGARTfNkkoDC7SUqED1yIQ4pSDZzCg1WAlNwkFBPQ=
 github.com/giantswarm/apiextensions/v3 v3.40.0 h1:P1QGmI6sd9Ql0g5cmPgSqcN5liMm7KkE5DzF+VH3Hps=
 github.com/giantswarm/apiextensions/v3 v3.40.0/go.mod h1:Pfw9GhojeehHf7gOPLwOVWQbUB1E/TS8ThqzfZOQsw4=
 github.com/giantswarm/backoff v1.0.0 h1:1oeTvyPsm1tJrHlSmfxbIWuoCNWPOkWJCb8kfLvE2T0=

--- a/pkg/giantnetes/utils.go
+++ b/pkg/giantnetes/utils.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 
 	"github.com/coreos/go-semver/semver"
-	"github.com/giantswarm/apiextensions/v3/pkg/apis/backup/v1alpha1"
+	"github.com/giantswarm/apiextensions-backup/api/v1alpha1"
 	"github.com/giantswarm/apiextensions/v3/pkg/apis/infrastructure/v1alpha3"
 	providerv1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/apiextensions/v3/pkg/label"

--- a/service/collector/etcdbackup.go
+++ b/service/collector/etcdbackup.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"sort"
 
-	"github.com/giantswarm/apiextensions/v3/pkg/apis/backup/v1alpha1"
+	"github.com/giantswarm/apiextensions-backup/api/v1alpha1"
 	"github.com/giantswarm/apiextensions/v3/pkg/apis/infrastructure/v1alpha3"
 	providerv1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"

--- a/service/controller/etcd_backup.go
+++ b/service/controller/etcd_backup.go
@@ -1,7 +1,7 @@
 package controller
 
 import (
-	backupv1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/backup/v1alpha1"
+	backupv1alpha1 "github.com/giantswarm/apiextensions-backup/api/v1alpha1"
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"

--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -3,7 +3,7 @@ package key
 import (
 	"fmt"
 
-	backupv1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/backup/v1alpha1"
+	backupv1alpha1 "github.com/giantswarm/apiextensions-backup/api/v1alpha1"
 	"github.com/giantswarm/microerror"
 )
 

--- a/service/controller/resource/etcdbackup/cleanup.go
+++ b/service/controller/resource/etcdbackup/cleanup.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/giantswarm/apiextensions/v3/pkg/apis/backup/v1alpha1"
+	"github.com/giantswarm/apiextensions-backup/api/v1alpha1"
 	"github.com/giantswarm/microerror"
 )
 

--- a/service/controller/resource/etcdbackup/create_running_v2.go
+++ b/service/controller/resource/etcdbackup/create_running_v2.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/giantswarm/apiextensions/v3/pkg/apis/backup/v1alpha1"
+	"github.com/giantswarm/apiextensions-backup/api/v1alpha1"
 	"github.com/giantswarm/microerror"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/service/controller/resource/etcdbackup/create_running_v3.go
+++ b/service/controller/resource/etcdbackup/create_running_v3.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/giantswarm/apiextensions/v3/pkg/apis/backup/v1alpha1"
+	"github.com/giantswarm/apiextensions-backup/api/v1alpha1"
 	"github.com/giantswarm/microerror"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/service/controller/resource/etcdbackup/instances.go
+++ b/service/controller/resource/etcdbackup/instances.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/giantswarm/apiextensions/v3/pkg/apis/backup/v1alpha1"
+	"github.com/giantswarm/apiextensions-backup/api/v1alpha1"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/v7/pkg/controller/context/reconciliationcanceledcontext"
 

--- a/service/controller/resource/etcdbackup/status.go
+++ b/service/controller/resource/etcdbackup/status.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	backupv1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/backup/v1alpha1"
+	backupv1alpha1 "github.com/giantswarm/apiextensions-backup/api/v1alpha1"
 	"github.com/giantswarm/microerror"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )

--- a/service/service.go
+++ b/service/service.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"sync"
 
-	backupv1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/backup/v1alpha1"
+	backupv1alpha1 "github.com/giantswarm/apiextensions-backup/api/v1alpha1"
 	infrastructurev1alpha3 "github.com/giantswarm/apiextensions/v3/pkg/apis/infrastructure/v1alpha3"
 	providerv1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"


### PR DESCRIPTION
CRD and golang types definitions have been moved from `apiextensions` to https://github.com/giantswarm/apiextensions-backup

This PR make etcd-backup-operator use the new repo for the golang types.