### PR TITLE
Use int64 to store revision returned by etcdctl so it fits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The `revision` data coming from `etcdctl` needs an `int64` to fit.
+
 ## [2.9.0] - 2022-02-03
 
 ### Changed

--- a/pkg/etcd/etcdv3.go
+++ b/pkg/etcd/etcdv3.go
@@ -50,7 +50,7 @@ func NewV3Backup(caCert string, cert string, encPass string, endpoints string, l
 	}
 }
 
-//clear temporary directory
+// Cleanup clears temporary directory
 func (b V3Backup) Cleanup() {
 	os.RemoveAll(b.getTmpDir())
 }
@@ -206,9 +206,9 @@ func (b V3Backup) runEtcdctlCmd(etcdctlArgs []string) ([]byte, error) {
 	return log, nil
 }
 
-func getRevision(output []byte) (int32, error) {
+func getRevision(output []byte) (int64, error) {
 	type endpointStatusOutputStatusHeader struct {
-		Revision int32
+		Revision int64
 	}
 
 	type endpointStatusOutputStatus struct {

--- a/pkg/etcd/etcdv3_test.go
+++ b/pkg/etcd/etcdv3_test.go
@@ -6,7 +6,7 @@ func Test_getRevistion(t *testing.T) {
 	tests := []struct {
 		name    string
 		output  string
-		want    int32
+		want    int64
 		wantErr bool
 	}{
 		{
@@ -17,8 +17,8 @@ func Test_getRevistion(t *testing.T) {
 		},
 		{
 			name:    "Valid response",
-			output:  `[{"Endpoint":"https://127.0.0.1:2379","Status":{"header":{"cluster_id":14841639068965178418,"member_id":11895648879011905400,"revision":197531225,"raft_term":48069},"version":"3.4.13","dbSize":79740928,"leader":1412153380952468371,"raftIndex":224800270,"raftTerm":48069}}]`,
-			want:    197531225,
+			output:  `[{"Endpoint":"https://127.0.0.1:2379","Status":{"header":{"cluster_id":14841639068965178418,"member_id":11895648879011905400,"revision":2208803470,"raft_term":48069},"version":"3.4.13","dbSize":79740928,"leader":1412153380952468371,"raftIndex":224800270,"raftTerm":48069}}]`,
+			want:    2208803470,
 			wantErr: false,
 		},
 	}


### PR DESCRIPTION
The operator was failing because
```
execution failed error: etcd 'v3' creation failed with error 'json: cannot unmarshal number 2208803470 into Go struct field endpointStatusOutputStatusHeader.Status.Header.Revision of type int32'
```