### PR TITLE
Try renovate gomodTidy1.17

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,7 +35,7 @@
       "allowedVersions": ">= 4.0.0"
     }
   ],
-  "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],
+  "postUpdateOptions": ["gomodTidy1.17", "gomodUpdateImportPaths"],
   "dependencyDashboard": true,
   "ignorePaths": [
     ".github/workflows/zz_generated.*",


### PR DESCRIPTION
We are getting some CI failures because the output of `go mod tidy` doesn't match between our CI and renovate. Let's try this option.