### PR TITLE
Ignore VPA configuration if VPA is not installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Ignore VPA configuration if VPA is not installed.
+
 ## [2.10.0] - 2022-02-24
 
 ### Changed

--- a/helm/etcd-backup-operator/templates/vpa.yaml
+++ b/helm/etcd-backup-operator/templates/vpa.yaml
@@ -1,3 +1,5 @@
+{{ if .Capabilities.APIVersions.Has "autoscaling.k8s.io/v1" }}
+{{ if .Values.verticalPodAutoscaler.enabled }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
@@ -8,7 +10,7 @@ metadata:
 spec:
   resourcePolicy:
     containerPolicies:
-      - containerName: {{ .Chart.Name }}
+      - containerName: {{ include "name" . }}
         controlledValues: RequestsAndLimits
         mode: Auto
   targetRef:
@@ -17,3 +19,5 @@ spec:
     name:  {{ include "resource.default.name" . }}
   updatePolicy:
     updateMode: Auto
+{{ end }}
+{{ end }}

--- a/helm/etcd-backup-operator/values.yaml
+++ b/helm/etcd-backup-operator/values.yaml
@@ -34,3 +34,6 @@ clientKeyFileName: ""
 etcdEndpoints: "https://127.0.0.1:2379"
 
 installation: ""
+
+verticalPodAutoscaler:
+  enabled: true


### PR DESCRIPTION
Currently, if VPA is not installed, this app fails to install with the following error

```
invalid manifest error: (unable to build kubernetes objects from release
    manifest: unable to recognize "": no matches for kind "VerticalPodAutoscaler"
    in version "autoscaling.k8s.io/v1")
```