### PR TITLE
Bump go module major version to v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Bump go module version in `go.mod`.
+
 ## [3.0.0] - 2022-03-31
 
 - Use `giantswarm/k8smetadata` for labels.

--- a/flag/flag.go
+++ b/flag/flag.go
@@ -3,7 +3,7 @@ package flag
 import (
 	"github.com/giantswarm/microkit/flag"
 
-	"github.com/giantswarm/etcd-backup-operator/v2/flag/service"
+	"github.com/giantswarm/etcd-backup-operator/v3/flag/service"
 )
 
 // Flag provides data structure for service command line flags.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/giantswarm/etcd-backup-operator/v2
+module github.com/giantswarm/etcd-backup-operator/v3
 
 go 1.17
 

--- a/main.go
+++ b/main.go
@@ -9,10 +9,10 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/viper"
 
-	"github.com/giantswarm/etcd-backup-operator/v2/flag"
-	"github.com/giantswarm/etcd-backup-operator/v2/pkg/project"
-	"github.com/giantswarm/etcd-backup-operator/v2/server"
-	"github.com/giantswarm/etcd-backup-operator/v2/service"
+	"github.com/giantswarm/etcd-backup-operator/v3/flag"
+	"github.com/giantswarm/etcd-backup-operator/v3/pkg/project"
+	"github.com/giantswarm/etcd-backup-operator/v3/server"
+	"github.com/giantswarm/etcd-backup-operator/v3/service"
 )
 
 var (

--- a/pkg/etcd/etcdv2.go
+++ b/pkg/etcd/etcdv2.go
@@ -13,9 +13,9 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/mholt/archiver/v3"
 
-	"github.com/giantswarm/etcd-backup-operator/v2/pkg/etcd/internal/encrypt"
-	"github.com/giantswarm/etcd-backup-operator/v2/pkg/etcd/internal/exec"
-	"github.com/giantswarm/etcd-backup-operator/v2/pkg/etcd/key"
+	"github.com/giantswarm/etcd-backup-operator/v3/pkg/etcd/internal/encrypt"
+	"github.com/giantswarm/etcd-backup-operator/v3/pkg/etcd/internal/exec"
+	"github.com/giantswarm/etcd-backup-operator/v3/pkg/etcd/key"
 )
 
 type V2Backup struct {

--- a/pkg/etcd/etcdv3.go
+++ b/pkg/etcd/etcdv3.go
@@ -14,9 +14,9 @@ import (
 	"github.com/mholt/archiver/v3"
 	"k8s.io/apimachinery/pkg/util/json"
 
-	"github.com/giantswarm/etcd-backup-operator/v2/pkg/etcd/internal/encrypt"
-	"github.com/giantswarm/etcd-backup-operator/v2/pkg/etcd/internal/exec"
-	"github.com/giantswarm/etcd-backup-operator/v2/pkg/etcd/key"
+	"github.com/giantswarm/etcd-backup-operator/v3/pkg/etcd/internal/encrypt"
+	"github.com/giantswarm/etcd-backup-operator/v3/pkg/etcd/internal/exec"
+	"github.com/giantswarm/etcd-backup-operator/v3/pkg/etcd/key"
 )
 
 type V3Backup struct {

--- a/server/endpoint/endpoint.go
+++ b/server/endpoint/endpoint.go
@@ -6,7 +6,7 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 
-	"github.com/giantswarm/etcd-backup-operator/v2/service"
+	"github.com/giantswarm/etcd-backup-operator/v3/service"
 )
 
 type Config struct {

--- a/server/server.go
+++ b/server/server.go
@@ -12,9 +12,9 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/viper"
 
-	"github.com/giantswarm/etcd-backup-operator/v2/pkg/project"
-	"github.com/giantswarm/etcd-backup-operator/v2/server/endpoint"
-	"github.com/giantswarm/etcd-backup-operator/v2/service"
+	"github.com/giantswarm/etcd-backup-operator/v3/pkg/project"
+	"github.com/giantswarm/etcd-backup-operator/v3/server/endpoint"
+	"github.com/giantswarm/etcd-backup-operator/v3/service"
 )
 
 type Config struct {

--- a/service/collector/etcdbackup.go
+++ b/service/collector/etcdbackup.go
@@ -12,7 +12,7 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/giantswarm/etcd-backup-operator/v2/service/controller/key"
+	"github.com/giantswarm/etcd-backup-operator/v3/service/controller/key"
 )
 
 const (

--- a/service/controller/etcd_backup.go
+++ b/service/controller/etcd_backup.go
@@ -9,9 +9,9 @@ import (
 	"github.com/giantswarm/operatorkit/v7/pkg/resource"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/giantswarm/etcd-backup-operator/v2/pkg/giantnetes"
-	"github.com/giantswarm/etcd-backup-operator/v2/pkg/project"
-	"github.com/giantswarm/etcd-backup-operator/v2/pkg/storage"
+	"github.com/giantswarm/etcd-backup-operator/v3/pkg/giantnetes"
+	"github.com/giantswarm/etcd-backup-operator/v3/pkg/project"
+	"github.com/giantswarm/etcd-backup-operator/v3/pkg/storage"
 )
 
 type ETCDBackupConfig struct {

--- a/service/controller/etcd_backup_resource_set.go
+++ b/service/controller/etcd_backup_resource_set.go
@@ -6,7 +6,7 @@ import (
 	"github.com/giantswarm/operatorkit/v7/pkg/resource/wrapper/metricsresource"
 	"github.com/giantswarm/operatorkit/v7/pkg/resource/wrapper/retryresource"
 
-	"github.com/giantswarm/etcd-backup-operator/v2/service/controller/resource/etcdbackup"
+	"github.com/giantswarm/etcd-backup-operator/v3/service/controller/resource/etcdbackup"
 )
 
 func validateETCDBackupResourceSetConfigConfig(config ETCDBackupConfig) error {

--- a/service/controller/resource/etcdbackup/backup.go
+++ b/service/controller/resource/etcdbackup/backup.go
@@ -9,8 +9,8 @@ import (
 	"github.com/giantswarm/backoff"
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/etcd-backup-operator/v2/pkg/etcd"
-	"github.com/giantswarm/etcd-backup-operator/v2/pkg/etcd/metrics"
+	"github.com/giantswarm/etcd-backup-operator/v3/pkg/etcd"
+	"github.com/giantswarm/etcd-backup-operator/v3/pkg/etcd/metrics"
 )
 
 func (r *Resource) performBackup(ctx context.Context, backupper etcd.Backupper, instanceName string) (*metrics.BackupAttemptResult, error) {

--- a/service/controller/resource/etcdbackup/create.go
+++ b/service/controller/resource/etcdbackup/create.go
@@ -7,8 +7,8 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/v7/pkg/controller/context/reconciliationcanceledcontext"
 
-	"github.com/giantswarm/etcd-backup-operator/v2/service/controller/key"
-	"github.com/giantswarm/etcd-backup-operator/v2/service/controller/resource/etcdbackup/internal/state"
+	"github.com/giantswarm/etcd-backup-operator/v3/service/controller/key"
+	"github.com/giantswarm/etcd-backup-operator/v3/service/controller/resource/etcdbackup/internal/state"
 )
 
 const (

--- a/service/controller/resource/etcdbackup/create_completed.go
+++ b/service/controller/resource/etcdbackup/create_completed.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/etcd-backup-operator/v2/service/controller/key"
-	"github.com/giantswarm/etcd-backup-operator/v2/service/controller/resource/etcdbackup/internal/state"
+	"github.com/giantswarm/etcd-backup-operator/v3/service/controller/key"
+	"github.com/giantswarm/etcd-backup-operator/v3/service/controller/resource/etcdbackup/internal/state"
 )
 
 // Deletes the ETCDBackup if it's older than the threshold.

--- a/service/controller/resource/etcdbackup/create_empty.go
+++ b/service/controller/resource/etcdbackup/create_empty.go
@@ -3,7 +3,7 @@ package etcdbackup
 import (
 	"context"
 
-	"github.com/giantswarm/etcd-backup-operator/v2/service/controller/resource/etcdbackup/internal/state"
+	"github.com/giantswarm/etcd-backup-operator/v3/service/controller/resource/etcdbackup/internal/state"
 )
 
 // Sets the initial state.

--- a/service/controller/resource/etcdbackup/create_failed.go
+++ b/service/controller/resource/etcdbackup/create_failed.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/etcd-backup-operator/v2/service/controller/key"
-	"github.com/giantswarm/etcd-backup-operator/v2/service/controller/resource/etcdbackup/internal/state"
+	"github.com/giantswarm/etcd-backup-operator/v3/service/controller/key"
+	"github.com/giantswarm/etcd-backup-operator/v3/service/controller/resource/etcdbackup/internal/state"
 )
 
 // Deletes the ETCDBackup if it's older than the threshold.

--- a/service/controller/resource/etcdbackup/create_pending.go
+++ b/service/controller/resource/etcdbackup/create_pending.go
@@ -7,8 +7,8 @@ import (
 	"github.com/giantswarm/microerror"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/etcd-backup-operator/v2/service/controller/key"
-	"github.com/giantswarm/etcd-backup-operator/v2/service/controller/resource/etcdbackup/internal/state"
+	"github.com/giantswarm/etcd-backup-operator/v3/service/controller/key"
+	"github.com/giantswarm/etcd-backup-operator/v3/service/controller/resource/etcdbackup/internal/state"
 )
 
 // Sets the StartedTimestamp for the global reconciliation and initializes the Status->Instances field.

--- a/service/controller/resource/etcdbackup/create_running_v2.go
+++ b/service/controller/resource/etcdbackup/create_running_v2.go
@@ -9,10 +9,10 @@ import (
 	"github.com/giantswarm/microerror"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/etcd-backup-operator/v2/pkg/etcd"
-	"github.com/giantswarm/etcd-backup-operator/v2/pkg/giantnetes"
-	"github.com/giantswarm/etcd-backup-operator/v2/service/controller/key"
-	"github.com/giantswarm/etcd-backup-operator/v2/service/controller/resource/etcdbackup/internal/state"
+	"github.com/giantswarm/etcd-backup-operator/v3/pkg/etcd"
+	"github.com/giantswarm/etcd-backup-operator/v3/pkg/giantnetes"
+	"github.com/giantswarm/etcd-backup-operator/v3/service/controller/key"
+	"github.com/giantswarm/etcd-backup-operator/v3/service/controller/resource/etcdbackup/internal/state"
 )
 
 func (r *Resource) backupRunningV2BackupRunningTransition(ctx context.Context, obj interface{}, currentState state.State) (state.State, error) {

--- a/service/controller/resource/etcdbackup/create_running_v2_completed.go
+++ b/service/controller/resource/etcdbackup/create_running_v2_completed.go
@@ -3,7 +3,7 @@ package etcdbackup
 import (
 	"context"
 
-	"github.com/giantswarm/etcd-backup-operator/v2/service/controller/resource/etcdbackup/internal/state"
+	"github.com/giantswarm/etcd-backup-operator/v3/service/controller/resource/etcdbackup/internal/state"
 )
 
 func (r *Resource) backupRunningV2BackupCompletedTransition(ctx context.Context, obj interface{}, currentState state.State) (state.State, error) {

--- a/service/controller/resource/etcdbackup/create_running_v3.go
+++ b/service/controller/resource/etcdbackup/create_running_v3.go
@@ -9,10 +9,10 @@ import (
 	"github.com/giantswarm/microerror"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/etcd-backup-operator/v2/pkg/etcd"
-	"github.com/giantswarm/etcd-backup-operator/v2/pkg/giantnetes"
-	"github.com/giantswarm/etcd-backup-operator/v2/service/controller/key"
-	"github.com/giantswarm/etcd-backup-operator/v2/service/controller/resource/etcdbackup/internal/state"
+	"github.com/giantswarm/etcd-backup-operator/v3/pkg/etcd"
+	"github.com/giantswarm/etcd-backup-operator/v3/pkg/giantnetes"
+	"github.com/giantswarm/etcd-backup-operator/v3/service/controller/key"
+	"github.com/giantswarm/etcd-backup-operator/v3/service/controller/resource/etcdbackup/internal/state"
 )
 
 func (r *Resource) backupRunningV3BackupRunningTransition(ctx context.Context, obj interface{}, currentState state.State) (state.State, error) {

--- a/service/controller/resource/etcdbackup/create_running_v3_completed.go
+++ b/service/controller/resource/etcdbackup/create_running_v3_completed.go
@@ -7,8 +7,8 @@ import (
 	"github.com/giantswarm/microerror"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/etcd-backup-operator/v2/service/controller/key"
-	"github.com/giantswarm/etcd-backup-operator/v2/service/controller/resource/etcdbackup/internal/state"
+	"github.com/giantswarm/etcd-backup-operator/v3/service/controller/key"
+	"github.com/giantswarm/etcd-backup-operator/v3/service/controller/resource/etcdbackup/internal/state"
 )
 
 func (r *Resource) backupRunningV3BackupCompletedTransition(ctx context.Context, obj interface{}, currentState state.State) (state.State, error) {

--- a/service/controller/resource/etcdbackup/instances.go
+++ b/service/controller/resource/etcdbackup/instances.go
@@ -8,8 +8,8 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/v7/pkg/controller/context/reconciliationcanceledcontext"
 
-	"github.com/giantswarm/etcd-backup-operator/v2/pkg/giantnetes"
-	"github.com/giantswarm/etcd-backup-operator/v2/service/controller/key"
+	"github.com/giantswarm/etcd-backup-operator/v3/pkg/giantnetes"
+	"github.com/giantswarm/etcd-backup-operator/v3/service/controller/key"
 )
 
 func (r *Resource) runBackupOnAllInstances(ctx context.Context, obj interface{}, handler func(context.Context, giantnetes.ETCDInstance, *v1alpha1.ETCDInstanceBackupStatusIndex) bool) (bool, error) {

--- a/service/controller/resource/etcdbackup/resource.go
+++ b/service/controller/resource/etcdbackup/resource.go
@@ -5,9 +5,9 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 
-	"github.com/giantswarm/etcd-backup-operator/v2/pkg/giantnetes"
-	"github.com/giantswarm/etcd-backup-operator/v2/pkg/storage"
-	"github.com/giantswarm/etcd-backup-operator/v2/service/controller/resource/etcdbackup/internal/state"
+	"github.com/giantswarm/etcd-backup-operator/v3/pkg/giantnetes"
+	"github.com/giantswarm/etcd-backup-operator/v3/pkg/storage"
+	"github.com/giantswarm/etcd-backup-operator/v3/service/controller/resource/etcdbackup/internal/state"
 )
 
 const (

--- a/service/service.go
+++ b/service/service.go
@@ -18,13 +18,13 @@ import (
 	"github.com/spf13/viper"
 	"k8s.io/client-go/rest"
 
-	"github.com/giantswarm/etcd-backup-operator/v2/flag"
-	"github.com/giantswarm/etcd-backup-operator/v2/pkg/giantnetes"
-	"github.com/giantswarm/etcd-backup-operator/v2/pkg/project"
-	"github.com/giantswarm/etcd-backup-operator/v2/pkg/storage"
-	"github.com/giantswarm/etcd-backup-operator/v2/service/collector"
-	"github.com/giantswarm/etcd-backup-operator/v2/service/controller"
-	"github.com/giantswarm/etcd-backup-operator/v2/service/controller/key"
+	"github.com/giantswarm/etcd-backup-operator/v3/flag"
+	"github.com/giantswarm/etcd-backup-operator/v3/pkg/giantnetes"
+	"github.com/giantswarm/etcd-backup-operator/v3/pkg/project"
+	"github.com/giantswarm/etcd-backup-operator/v3/pkg/storage"
+	"github.com/giantswarm/etcd-backup-operator/v3/service/collector"
+	"github.com/giantswarm/etcd-backup-operator/v3/service/controller"
+	"github.com/giantswarm/etcd-backup-operator/v3/service/controller/key"
 )
 
 // Config represents the configuration used to create a new service.


### PR DESCRIPTION
I released v3 but I forgot to bump the go module version.