### PR TITLE
backup-capi-clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add functionality to backup CAPI clusters.
+
 ## [3.1.0] - 2022-06-15
 
 ### Added

--- a/flag/service/service.go
+++ b/flag/service/service.go
@@ -6,10 +6,11 @@ import (
 
 // Service is an intermediate data structure for command line configuration flags.
 type Service struct {
-	Kubernetes   kubernetes.Kubernetes
-	S3           S3Uploader
-	ETCDv2       ETCDv2Settings
-	ETCDv3       ETCDv3Settings
-	Installation string
-	Sentry       Sentry
+	Kubernetes                  kubernetes.Kubernetes
+	S3                          S3Uploader
+	SkipManagementClusterBackup string
+	ETCDv2                      ETCDv2Settings
+	ETCDv3                      ETCDv3Settings
+	Installation                string
+	Sentry                      Sentry
 }

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/giantswarm/operatorkit/v7 v7.0.1
 	github.com/google/go-cmp v0.5.8
 	github.com/mholt/archiver/v3 v3.5.1
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.2
 	github.com/spf13/viper v1.12.0
 	go.etcd.io/etcd/client/v3 v3.5.4
@@ -27,12 +28,14 @@ require (
 	k8s.io/api v0.24.1
 	k8s.io/apimachinery v0.24.1
 	k8s.io/client-go v0.24.1
+	sigs.k8s.io/cluster-api v1.0.4
 	sigs.k8s.io/controller-runtime v0.12.1
 )
 
 require (
 	github.com/andybalholm/brotli v1.0.4 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/cenkalti/backoff/v4 v4.1.3 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
@@ -52,6 +55,7 @@ require (
 	github.com/go-openapi/jsonreference v0.20.0 // indirect
 	github.com/go-openapi/swag v0.21.1 // indirect
 	github.com/go-stack/stack v1.8.1 // indirect
+	github.com/gobuffalo/flect v0.2.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
@@ -72,6 +76,7 @@ require (
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
+	github.com/moby/spdystream v0.2.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
@@ -80,7 +85,6 @@ require (
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.2 // indirect
 	github.com/pierrec/lz4/v4 v4.1.14 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.34.0 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
@@ -114,6 +118,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.24.1 // indirect
+	k8s.io/cluster-bootstrap v0.22.2 // indirect
 	k8s.io/component-base v0.24.1 // indirect
 	k8s.io/klog/v2 v2.60.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220603121420-31174f50af60 // indirect

--- a/go.sum
+++ b/go.sum
@@ -162,6 +162,7 @@ github.com/armon/go-metrics v0.3.9/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4
 github.com/armon/go-metrics v0.3.10/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
@@ -187,6 +188,7 @@ github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngE
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
 github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
@@ -392,6 +394,7 @@ github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385/go.mod h1:0vRUJqYpeSZifjYj7uP3BG/gKcuzL9xWVV/Y+cK33KM=
+github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible h1:spTtZBk5DYEvbxMVutUuTyh1Ao2r4iyvLdACqsl/Ljk=
@@ -544,6 +547,7 @@ github.com/go-stack/stack v1.8.1 h1:ntEHSVwIt7PNXNpgPmVfMrNhLtgjlmnZha2kOpuRiDw=
 github.com/go-stack/stack v1.8.1/go.mod h1:dcoOX6HbPZSZptuspn9bctJ+N/CnF5gGygcUP3XYfe4=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-zookeeper/zk v1.0.2/go.mod h1:nOB03cncLtlp4t+UAkGSV+9beXP/akpekBwL+UX1Qcw=
+github.com/gobuffalo/flect v0.2.3 h1:f/ZukRnSNA/DUpSNDadko7Qc0PhGvsew35p/2tu+CRY=
 github.com/gobuffalo/flect v0.2.3/go.mod h1:vmkQwuZYhN5Pc4ljYQZzP+1sq+NEkK+lh20jmEmX3jc=
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee/go.mod h1:L0fX3K22YWvt/FAX9NnzrNzcI4wNYi9Yku4O0LKYflo=
 github.com/gobwas/pool v0.2.0/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
@@ -904,6 +908,7 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
+github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/moby/sys/mountinfo v0.4.0/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=
 github.com/moby/sys/mountinfo v0.4.1/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=
@@ -2069,6 +2074,7 @@ k8s.io/client-go v0.22.2/go.mod h1:sAlhrkVDf50ZHx6z4K0S40wISNTarf1r800F+RlCF6U=
 k8s.io/client-go v0.24.0/go.mod h1:VFPQET+cAFpYxh6Bq6f4xyMY80G6jKKktU6G0m00VDw=
 k8s.io/client-go v0.24.1 h1:w1hNdI9PFrzu3OlovVeTnf4oHDt+FJLd9Ndluvnb42E=
 k8s.io/client-go v0.24.1/go.mod h1:f1kIDqcEYmwXS/vTbbhopMUbhKp2JhOeVTfxgaCIlF8=
+k8s.io/cluster-bootstrap v0.22.2 h1:jP6Nkp3CdSfr50cAn/7WGsNS52zrwMhvr0V+E3Vkh/w=
 k8s.io/cluster-bootstrap v0.22.2/go.mod h1:ZkmQKprEqvrUccMnbRHISsMscA1dsQ8SffM9nHq6CgE=
 k8s.io/code-generator v0.20.1/go.mod h1:UsqdF+VX4PU2g46NC2JRs4gc+IfrctnwHb76RNbWHJg=
 k8s.io/code-generator v0.20.12/go.mod h1:MN7M2OmA4DntSwTmKqoB92uDBwM+OE0XtZ9piV7SXG4=
@@ -2128,6 +2134,7 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.14/go.mod h1:LEScyz
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.22/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.30/go.mod h1:fEO7lRTdivWO2qYVCVG7dEADOMo/MLDCVr8So2g88Uw=
+sigs.k8s.io/cluster-api v1.0.4 h1:3vMvQjEmkSQayN9r0DXlfn8uWHzqNT+HPBveVryJ1Dc=
 sigs.k8s.io/cluster-api v1.0.4/go.mod h1:/LkJXtsvhxTV4U0z1Y2Y1Gr2xebJ0/ce09Ab2M0XU/U=
 sigs.k8s.io/cluster-api-provider-azure v1.0.1/go.mod h1:T8MQq12kJi/N0MZLTIhFR8aPqeriXVluvLPJjWO7bCw=
 sigs.k8s.io/cluster-api/test v1.0.1/go.mod h1:D8eLfLrzKcPbm/TzYexoRJISaDleOGSpBrBvH0yVEuA=

--- a/helm/etcd-backup-operator/templates/configmap.yaml
+++ b/helm/etcd-backup-operator/templates/configmap.yaml
@@ -24,7 +24,7 @@ data:
       s3:
         bucket: "{{ .Values.aws.s3bucket }}"
         region: "{{ .Values.aws.s3region }}"
-      skipManagementClusterBackup: {{.Values.skipManagementClusterBackup}}
+      skipmanagementclusterbackup: {{.Values.skipManagementClusterBackup}}
       etcdv2:
         datadir: "{{ if eq .Values.provider.kind "kvm" }}/var/lib/etcd{{ end }}"
       etcdv3:

--- a/helm/etcd-backup-operator/templates/configmap.yaml
+++ b/helm/etcd-backup-operator/templates/configmap.yaml
@@ -24,6 +24,7 @@ data:
       s3:
         bucket: "{{ .Values.aws.s3bucket }}"
         region: "{{ .Values.aws.s3region }}"
+      skipManagementClusterBackup: {{.Values.skipManagementClusterBackup}}
       etcdv2:
         datadir: "{{ if eq .Values.provider.kind "kvm" }}/var/lib/etcd{{ end }}"
       etcdv3:

--- a/helm/etcd-backup-operator/templates/rbac.yaml
+++ b/helm/etcd-backup-operator/templates/rbac.yaml
@@ -41,6 +41,14 @@ rules:
       - customresourcedefinitions
     verbs:
       - "*"
+  - apiGroups:
+      - cluster.x-k8s.io
+    resources:
+      - clusters
+      - clusters/status
+    verbs:
+      - get
+      - list
   - nonResourceURLs:
       - "/"
       - "/healthz"

--- a/helm/etcd-backup-operator/values.schema.json
+++ b/helm/etcd-backup-operator/values.schema.json
@@ -42,6 +42,9 @@
         "etcdEndpoints": {
             "type": "string"
         },
+        "skipManagementClusterBackup": {
+            "type": "boolean"
+        },
         "image": {
             "type": "object",
             "properties": {

--- a/helm/etcd-backup-operator/values.yaml
+++ b/helm/etcd-backup-operator/values.yaml
@@ -40,7 +40,7 @@ clientCaCertFileName: ""
 clientCertFileName: ""
 clientKeyFileName: ""
 etcdEndpoints: "https://127.0.0.1:2379"
-
+skipManagementClusterBackup: false
 installation: ""
 
 verticalPodAutoscaler:

--- a/main.go
+++ b/main.go
@@ -107,6 +107,7 @@ func mainE(ctx context.Context) error {
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.TLS.CAFile, "", "Certificate authority file path to use to authenticate with Kubernetes.")
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.TLS.CrtFile, "", "Certificate file path to use to authenticate with Kubernetes.")
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.TLS.KeyFile, "", "Key file path to use to authenticate with Kubernetes.")
+	daemonCommand.PersistentFlags().Bool(f.Service.SkipManagementClusterBackup, false, "Skip management cluster backup.")
 	daemonCommand.PersistentFlags().String(f.Service.S3.Bucket, "", "AWS S3 Bucket name.")
 	daemonCommand.PersistentFlags().String(f.Service.S3.Region, "", "AWS S3 Region name.")
 	daemonCommand.PersistentFlags().String(f.Service.ETCDv2.DataDir, "", "ETCD v2 Data Dir path.")

--- a/pkg/etcd/etcdv3.go
+++ b/pkg/etcd/etcdv3.go
@@ -128,7 +128,7 @@ func (b V3Backup) Create() (string, error) {
 	*b.filename = *b.filename + key.TgzExt
 	fpath = filepath.Join(b.getTmpDir(), *b.filename)
 
-	b.Logger.Log("level", "info", "msg", "Etcd v3 backup created successfully")
+	b.Logger.Log("level", "info", "msg", "Etcd v3 backup created successfully", "file", b.filename)
 	return fpath, nil
 }
 

--- a/pkg/etcd/proxy/addr.go
+++ b/pkg/etcd/proxy/addr.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package proxy implements kubeadm proxy functionality.
+package proxy
+
+import (
+	"fmt"
+	"net"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/portforward"
+)
+
+const scheme string = "proxy"
+
+// Addr defines a proxy net/addr format.
+type Addr struct {
+	net.Addr
+	port       string
+	identifier uint32
+}
+
+// Network returns a fake network.
+func (a Addr) Network() string {
+	return portforward.PortForwardProtocolV1Name
+}
+
+// String returns encoded information about the connection.
+func (a Addr) String() string {
+	return fmt.Sprintf(
+		"%s://%d.%s.local:%s",
+		scheme,
+		a.identifier,
+		portforward.PortForwardProtocolV1Name,
+		a.port,
+	)
+}
+
+// NewAddrFromConn creates an Addr from the given connection.
+func NewAddrFromConn(c *Conn) Addr {
+	return Addr{
+		port:       c.stream.Headers().Get(corev1.PortHeader),
+		identifier: c.stream.Identifier(),
+	}
+}

--- a/pkg/etcd/proxy/addr.go
+++ b/pkg/etcd/proxy/addr.go
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// taken from https://github.com/kubernetes-sigs/cluster-api/tree/main/controlplane/kubeadm/internal/proxy
+
 // Package proxy implements kubeadm proxy functionality.
 package proxy
 

--- a/pkg/etcd/proxy/conn.go
+++ b/pkg/etcd/proxy/conn.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"net"
+	"time"
+
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/httpstream"
+)
+
+// Conn is a Kubernetes API server proxied type of net/conn.
+type Conn struct {
+	connection    httpstream.Connection
+	stream        httpstream.Stream
+	readDeadline  time.Time
+	writeDeadline time.Time
+}
+
+// Read from the connection.
+func (c *Conn) Read(b []byte) (n int, err error) {
+	return c.stream.Read(b)
+}
+
+// Close the underlying proxied connection.
+func (c *Conn) Close() error {
+	return kerrors.NewAggregate([]error{c.stream.Close(), c.connection.Close()})
+}
+
+// Write to the connection.
+func (c *Conn) Write(b []byte) (n int, err error) {
+	return c.stream.Write(b)
+}
+
+// LocalAddr returns a fake address representing the proxied connection.
+func (c *Conn) LocalAddr() net.Addr {
+	return NewAddrFromConn(c)
+}
+
+// RemoteAddr returns a fake address representing the proxied connection.
+func (c *Conn) RemoteAddr() net.Addr {
+	return NewAddrFromConn(c)
+}
+
+// SetDeadline sets the read and write deadlines to the specified interval.
+func (c *Conn) SetDeadline(t time.Time) error {
+	// TODO: Handle deadlines
+	c.readDeadline = t
+	c.writeDeadline = t
+	return nil
+}
+
+// SetWriteDeadline sets the read and write deadlines to the specified interval.
+func (c *Conn) SetWriteDeadline(t time.Time) error {
+	c.writeDeadline = t
+	return nil
+}
+
+// SetReadDeadline sets the read and write deadlines to the specified interval.
+func (c *Conn) SetReadDeadline(t time.Time) error {
+	c.readDeadline = t
+	return nil
+}
+
+// NewConn creates a new net/conn interface based on an underlying Kubernetes
+// API server proxy connection.
+func NewConn(connection httpstream.Connection, stream httpstream.Stream) *Conn {
+	return &Conn{
+		connection: connection,
+		stream:     stream,
+	}
+}

--- a/pkg/etcd/proxy/conn.go
+++ b/pkg/etcd/proxy/conn.go
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// taken from https://github.com/kubernetes-sigs/cluster-api/tree/main/controlplane/kubeadm/internal/proxy
+
 package proxy
 
 import (

--- a/pkg/etcd/proxy/dial.go
+++ b/pkg/etcd/proxy/dial.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+)
+
+const defaultTimeout = 10 * time.Second
+
+// Dialer creates connections using Kubernetes API Server port-forwarding.
+type Dialer struct {
+	proxy          Proxy
+	clientset      *kubernetes.Clientset
+	proxyTransport http.RoundTripper
+	upgrader       spdy.Upgrader
+	timeout        time.Duration
+}
+
+// NewDialer creates a new dialer for a given API server scope.
+func NewDialer(p Proxy, options ...func(*Dialer) error) (*Dialer, error) {
+	if p.Port == 0 {
+		return nil, errors.New("port required")
+	}
+
+	dialer := &Dialer{
+		proxy: p,
+	}
+
+	for _, option := range options {
+		err := option(dialer)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if dialer.timeout == 0 {
+		dialer.timeout = defaultTimeout
+	}
+	p.KubeConfig.Timeout = dialer.timeout
+	clientset, err := kubernetes.NewForConfig(p.KubeConfig)
+	if err != nil {
+		return nil, err
+	}
+	proxyTransport, upgrader, err := spdy.RoundTripperFor(p.KubeConfig)
+	if err != nil {
+		return nil, err
+	}
+	dialer.proxyTransport = proxyTransport
+	dialer.upgrader = upgrader
+	dialer.clientset = clientset
+	return dialer, nil
+}
+
+// DialContextWithAddr is a GO grpc compliant dialer construct.
+func (d *Dialer) DialContextWithAddr(ctx context.Context, addr string) (net.Conn, error) {
+	return d.DialContext(ctx, scheme, addr)
+}
+
+// DialContext creates proxied port-forwarded connections.
+// ctx is currently unused, but fulfils the type signature used by GRPC.
+func (d *Dialer) DialContext(_ context.Context, network string, addr string) (net.Conn, error) {
+	req := d.clientset.CoreV1().RESTClient().
+		Post().
+		Resource(d.proxy.Kind).
+		Namespace(d.proxy.Namespace).
+		Name(addr).
+		SubResource("portforward")
+
+	dialer := spdy.NewDialer(d.upgrader, &http.Client{Transport: d.proxyTransport}, "POST", req.URL())
+
+	// Create a new connection from the dialer.
+	//
+	// Warning: Any early return should close this connection, otherwise we're going to leak them.
+	connection, _, err := dialer.Dial(portforward.PortForwardProtocolV1Name)
+	if err != nil {
+		return nil, errors.Wrap(err, "error upgrading connection")
+	}
+
+	// Create the headers.
+	headers := http.Header{}
+
+	// Set the header port number to match the proxy one.
+	headers.Set(corev1.PortHeader, fmt.Sprintf("%d", d.proxy.Port))
+
+	// We only create a single stream over the connection
+	headers.Set(corev1.PortForwardRequestIDHeader, "0")
+
+	// Create the error stream.
+	headers.Set(corev1.StreamType, corev1.StreamTypeError)
+	errorStream, err := connection.CreateStream(headers)
+	if err != nil {
+		return nil, kerrors.NewAggregate([]error{
+			err,
+			connection.Close(),
+		})
+	}
+	// Close the error stream right away, we're not writing to it.
+	if err := errorStream.Close(); err != nil {
+		return nil, kerrors.NewAggregate([]error{
+			err,
+			connection.Close(),
+		})
+	}
+
+	// Create the data stream.
+	//
+	// NOTE: Given that we're reusing the headers,
+	// we need to overwrite the stream type before creating it.
+	headers.Set(corev1.StreamType, corev1.StreamTypeData)
+	dataStream, err := connection.CreateStream(headers)
+	if err != nil {
+		return nil, kerrors.NewAggregate([]error{
+			errors.Wrap(err, "error creating forwarding stream"),
+			connection.Close(),
+		})
+	}
+
+	// Create the net.Conn and return.
+	return NewConn(connection, dataStream), nil
+}
+
+// DialTimeout sets the timeout.
+func DialTimeout(duration time.Duration) func(*Dialer) error {
+	return func(d *Dialer) error {
+		return d.setTimeout(duration)
+	}
+}
+
+func (d *Dialer) setTimeout(duration time.Duration) error {
+	d.timeout = duration
+	return nil
+}

--- a/pkg/etcd/proxy/dial.go
+++ b/pkg/etcd/proxy/dial.go
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// taken from https://github.com/kubernetes-sigs/cluster-api/tree/main/controlplane/kubeadm/internal/proxy
+
 package proxy
 
 import (

--- a/pkg/etcd/proxy/proxy.go
+++ b/pkg/etcd/proxy/proxy.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"crypto/tls"
+	"time"
+
+	"k8s.io/client-go/rest"
+)
+
+// Proxy defines the API server port-forwarded proxy.
+type Proxy struct {
+
+	// Kind is the kind of Kubernetes resource
+	Kind string
+
+	// Namespace is the namespace in which the Kubernetes resource exists
+	Namespace string
+
+	// ResourceName is the name of the Kubernetes resource
+	ResourceName string
+
+	// KubeConfig is the config to connect to the API server
+	KubeConfig *rest.Config
+
+	// TLSConfig is for connecting to TLS servers listening on a proxied port
+	TLSConfig *tls.Config
+
+	// KeepAlive specifies how often a keep alive message is sent to hold
+	// the connection open
+	KeepAlive *time.Duration
+
+	// Port is the port to be forwarded from the relevant resource
+	Port int
+}

--- a/pkg/etcd/proxy/proxy.go
+++ b/pkg/etcd/proxy/proxy.go
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// taken from https://github.com/kubernetes-sigs/cluster-api/tree/main/controlplane/kubeadm/internal/proxy
+
 package proxy
 
 import (

--- a/pkg/giantnetes/key.go
+++ b/pkg/giantnetes/key.go
@@ -2,7 +2,6 @@ package giantnetes
 
 import (
 	"fmt"
-	"path"
 
 	"github.com/coreos/go-semver/semver"
 )
@@ -12,6 +11,13 @@ const (
 	awsCAPI = "awsCAPI"
 	azure   = "azure"
 	kvm     = "kvm"
+	CAPI    = "capi"
+)
+
+const (
+	componentETCD = "etcd"
+
+	LabelCAPIControlPlaneNode = "node-role.kubernetes.io/control-plane=''"
 )
 
 var azureSupportFrom *semver.Version = semver.Must(semver.NewVersion("0.2.0"))
@@ -24,18 +30,10 @@ func AzureEtcdEndpoint(etcdDomain string) string {
 	return fmt.Sprintf("https://%s:2379", etcdDomain)
 }
 
-func CAFile(clusterID string, tmpDir string) string {
-	return path.Join(tmpDir, fmt.Sprintf("%s-%s.pem", clusterID, "ca"))
-}
-
-func CertFile(clusterID string, tmpDir string) string {
-	return path.Join(tmpDir, fmt.Sprintf("%s-%s.pem", clusterID, "crt"))
-}
-
-func KeyFile(clusterID string, tmpDir string) string {
-	return path.Join(tmpDir, fmt.Sprintf("%s-%s.pem", clusterID, "key"))
-}
-
 func KVMEtcdEndpoint(etcdDomain string) string {
 	return fmt.Sprintf("https://%s:443", etcdDomain)
+}
+
+func CAPIEtcdEndpoint(component string, nodeName string) string {
+	return fmt.Sprintf("%s-%s", component, nodeName)
 }

--- a/pkg/giantnetes/types.go
+++ b/pkg/giantnetes/types.go
@@ -2,6 +2,8 @@ package giantnetes
 
 import (
 	"crypto/tls"
+
+	"github.com/giantswarm/etcd-backup-operator/v3/pkg/etcd/proxy"
 )
 
 type ETCDv2Settings struct {
@@ -10,6 +12,7 @@ type ETCDv2Settings struct {
 
 type ETCDv3Settings struct {
 	Endpoints string
+	Proxy     *proxy.Proxy
 	TLSConfig *tls.Config
 }
 

--- a/pkg/giantnetes/utils.go
+++ b/pkg/giantnetes/utils.go
@@ -157,23 +157,19 @@ func (u *Utils) checkClusterVersionSupport(ctx context.Context, cluster Cluster)
 }
 
 func (u *Utils) getEtcdTLSCfg(ctx context.Context, cluster Cluster) (*tls.Config, error) {
-
 	if cluster.provider == CAPI {
 		t, err := u.getCAPIEtcdTLSCfg(ctx, cluster.clusterKey)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
 		return t, nil
-
 	} else {
 		t, err := u.getLegacyEtcdTLSCfg(ctx, cluster.clusterKey)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
-
 		return t, nil
 	}
-
 }
 
 // Fetch ETCD client certs.

--- a/pkg/giantnetes/utils.go
+++ b/pkg/giantnetes/utils.go
@@ -2,10 +2,11 @@ package giantnetes
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
+	"strings"
 
 	"github.com/coreos/go-semver/semver"
-	"github.com/giantswarm/apiextensions-backup/api/v1alpha1"
 	"github.com/giantswarm/apiextensions/v6/pkg/apis/infrastructure/v1alpha3"
 	providerv1alpha1 "github.com/giantswarm/apiextensions/v6/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
@@ -13,8 +14,13 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/secret"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/giantswarm/etcd-backup-operator/v3/pkg/etcd/proxy"
 	"github.com/giantswarm/etcd-backup-operator/v3/service/controller/key"
 )
 
@@ -29,9 +35,8 @@ type Utils struct {
 }
 
 type Cluster struct {
-	clusterID        string
-	clusterNamespace string
-	provider         string
+	clusterKey ctrl.ObjectKey
+	provider   string
 }
 
 func NewUtils(logger micrologger.Logger, client k8sclient.Interface) (*Utils, error) {
@@ -48,10 +53,10 @@ func NewUtils(logger micrologger.Logger, client k8sclient.Interface) (*Utils, er
 	}, nil
 }
 
-func (u *Utils) GetTenantClusters(ctx context.Context, backup v1alpha1.ETCDBackup) ([]ETCDInstance, error) {
+func (u *Utils) GetTenantClusters(ctx context.Context) ([]ETCDInstance, error) {
 	var instances []ETCDInstance
 
-	clusterList, err := u.getAllGuestClusters(ctx, u.K8sClient.CtrlClient())
+	clusterList, err := u.getAllWorkloadClusters(ctx, u.K8sClient.CtrlClient())
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
@@ -59,44 +64,47 @@ func (u *Utils) GetTenantClusters(ctx context.Context, backup v1alpha1.ETCDBacku
 	u.logger.LogCtx(ctx, "level", "debug", fmt.Sprintf("Found %d tenant clusters", len(clusterList)))
 
 	for _, cluster := range clusterList {
-		u.logger.LogCtx(ctx, "level", "debug", fmt.Sprintf("Preparing instance entry for tenant clusters %s", cluster.clusterID))
+		u.logger.LogCtx(ctx, "level", "debug", fmt.Sprintf("Preparing instance entry for tenant clusters %s", cluster.clusterKey.Name))
 
 		// Check if the cluster release version has support for ETCD backup.
 		versionSupported, err := u.checkClusterVersionSupport(ctx, cluster)
 		if err != nil {
-			u.logger.LogCtx(ctx, "level", "error", "msg", fmt.Sprintf("Failed to check release version for cluster %s", cluster.clusterID), "reason", err)
+			u.logger.LogCtx(ctx, "level", "error", "msg", fmt.Sprintf("Failed to check release version for cluster %s", cluster.clusterKey.Name), "reason", err)
 			continue
 		}
 		if !versionSupported {
-			u.logger.LogCtx(ctx, "level", "warning", "msg", fmt.Sprintf("Cluster %s is too old for etcd backup. Skipping.", cluster.clusterID))
+			u.logger.LogCtx(ctx, "level", "warning", "msg", fmt.Sprintf("Cluster %s is too old for etcd backup. Skipping.", cluster.clusterKey.Name))
 			continue
 		}
 
-		// Fetch ETCD certs.
-		certs, err := u.getLegacyEtcdTLSCfg(ctx, cluster.clusterID, cluster.clusterNamespace)
+		// Prepare ETCD tls config.
+		tlsConfig, err := u.getEtcdTLSCfg(ctx, cluster)
 		if err != nil {
-			u.logger.LogCtx(ctx, "level", "error", "msg", fmt.Sprintf("Failed to fetch etcd certs for cluster %s", cluster.clusterID), "reason", err)
-			continue
-		}
-		tlsConfig, err := key.PrepareTLSConfig(certs.CAData, certs.CrtData, certs.KeyData)
-		if err != nil {
-			u.logger.LogCtx(ctx, "level", "error", "msg", fmt.Sprintf("Failed to prepare tls config  from  etcd certs for cluster %s", cluster.clusterID), "reason", err)
+			u.logger.LogCtx(ctx, "level", "error", "msg", fmt.Sprintf("Failed to fetch etcd certs for cluster %s", cluster.clusterKey.Name), "reason", err)
 			continue
 		}
 
 		// Fetch ETCD endpoint.
 		etcdEndpoint, err := u.getEtcdEndpoint(ctx, cluster)
 		if err != nil {
-			u.logger.LogCtx(ctx, "level", "error", "msg", fmt.Sprintf("Failed to fetch etcd endpoint for cluster %s", cluster.clusterID), "reason", err)
+			u.logger.LogCtx(ctx, "level", "error", "msg", fmt.Sprintf("Failed to fetch etcd endpoint for cluster %s", cluster.clusterKey.Name), "reason", err)
+			continue
+		}
+
+		// prepare etcd proxy
+		p, err := u.getEtcdProxy(ctx, cluster, tlsConfig)
+		if err != nil {
+			u.logger.LogCtx(ctx, "level", "error", "msg", fmt.Sprintf("Failed to prepare etcd proxy for cluster %s", cluster.clusterKey.Name), "reason", err)
 			continue
 		}
 
 		instances = append(instances, ETCDInstance{
-			Name:   cluster.clusterID,
+			Name:   cluster.clusterKey.Name,
 			ETCDv2: ETCDv2Settings{},
 			ETCDv3: ETCDv3Settings{
 				Endpoints: etcdEndpoint,
 				TLSConfig: tlsConfig,
+				Proxy:     p,
 			},
 		})
 	}
@@ -116,9 +124,9 @@ func (u *Utils) checkClusterVersionSupport(ctx context.Context, cluster Cluster)
 	case azure:
 		{
 			crd := providerv1alpha1.AzureConfig{}
-			err := crdClient.Get(ctx, client.ObjectKey{Namespace: cluster.clusterNamespace, Name: cluster.clusterID}, &crd)
+			err := crdClient.Get(ctx, cluster.clusterKey, &crd)
 			if err != nil {
-				return false, microerror.Maskf(executionFailedError, fmt.Sprintf("failed to get azure crd %#q with error %#q", cluster.clusterID, err))
+				return false, microerror.Maskf(executionFailedError, fmt.Sprintf("failed to get azure crd %#q with error %#q", cluster.clusterKey.Name, err))
 			}
 			var version string
 			{
@@ -130,7 +138,7 @@ func (u *Utils) checkClusterVersionSupport(ctx context.Context, cluster Cluster)
 				}
 			}
 			if version == "" {
-				return false, microerror.Maskf(executionFailedError, fmt.Sprintf("failed to get cluster version from AzureConfig %#q", cluster.clusterID))
+				return false, microerror.Maskf(executionFailedError, fmt.Sprintf("failed to get cluster version from AzureConfig %#q", cluster.clusterKey.Name))
 			}
 			return stringVersionCmp(version, semver.New("0.0.0"), azureSupportFrom)
 		}
@@ -139,35 +147,114 @@ func (u *Utils) checkClusterVersionSupport(ctx context.Context, cluster Cluster)
 			// KVM backups are always supported.
 			return true, nil
 		}
+	case CAPI:
+		{
+			// CAPI backups are always supported.
+			return true, nil
+		}
 	}
 	return false, nil
 }
 
+func (u *Utils) getEtcdTLSCfg(ctx context.Context, cluster Cluster) (*tls.Config, error) {
+
+	if cluster.provider == CAPI {
+		t, err := u.getCAPIEtcdTLSCfg(ctx, cluster.clusterKey)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+		return t, nil
+
+	} else {
+		t, err := u.getLegacyEtcdTLSCfg(ctx, cluster.clusterKey)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		return t, nil
+	}
+
+}
+
 // Fetch ETCD client certs.
-func (u *Utils) getLegacyEtcdTLSCfg(ctx context.Context, clusterID string, clusterNamespace string) (*TLSClientConfig, error) {
+func (u *Utils) getLegacyEtcdTLSCfg(ctx context.Context, clusterKey ctrl.ObjectKey) (*tls.Config, error) {
 	k8sClient := u.K8sClient.CtrlClient()
 	secrets := v1.SecretList{}
 	err := k8sClient.List(ctx, &secrets, client.MatchingLabels{
-		label.Cluster:    clusterID,
+		label.Cluster:    clusterKey.Name,
 		certificateLabel: certificateLabelValue,
 	})
 	if err != nil {
-		return nil, microerror.Maskf(executionFailedError, "error getting etcd client certificates for guest cluster %#q with error %#q", clusterID, err)
+		return nil, microerror.Maskf(executionFailedError, "error getting etcd client certificates for guest cluster %#q with error %#q", clusterKey.Name, err)
 	}
 
 	if len(secrets.Items) != 1 {
-		return nil, microerror.Maskf(executionFailedError, "expected exactly 1 secret with %s=%q and %s=%q, got %d", label.Cluster, clusterID, certificateLabel, certificateLabelValue, len(secrets.Items))
+		return nil, microerror.Maskf(executionFailedError, "expected exactly 1 secret with %s=%q and %s=%q, got %d", label.Cluster, clusterKey.Name, certificateLabel, certificateLabelValue, len(secrets.Items))
 	}
 
-	secret := secrets.Items[0]
+	s := secrets.Items[0]
 
-	certs := &TLSClientConfig{
-		CAData:  secret.Data["ca"],
-		KeyData: secret.Data["key"],
-		CrtData: secret.Data["crt"],
+	tlsConfig, err := key.PrepareTLSConfig(s.Data["ca"], s.Data["crt"], s.Data["key"])
+	if err != nil {
+		return nil, microerror.Mask(err)
 	}
 
-	return certs, nil
+	return tlsConfig, nil
+}
+
+// Fetch ETCD client certs.
+func (u *Utils) getEtcdProxy(ctx context.Context, cluster Cluster, tlsConfig *tls.Config) (*proxy.Proxy, error) {
+	if cluster.provider == CAPI {
+		ctrClient := u.K8sClient.CtrlClient()
+
+		targetClusterRESTConfig, err := key.RESTConfig(ctx, ctrClient, cluster.clusterKey)
+		if err != nil {
+			return nil, microerror.Maskf(executionFailedError, "error fetching CAPI cluster rest config for cluster  %#q with error %#q", cluster.clusterKey.Name, err)
+		}
+
+		p := &proxy.Proxy{
+			Kind:       "pods",
+			Namespace:  metav1.NamespaceSystem,
+			KubeConfig: targetClusterRESTConfig,
+			TLSConfig:  tlsConfig,
+			Port:       2379,
+		}
+
+		return p, nil
+
+	} else {
+		// no proxy needed for legacy clusters
+		return nil, nil
+	}
+}
+
+// Fetch ETCD client certs for CAPI cluster.
+func (u *Utils) getCAPIEtcdTLSCfg(ctx context.Context, clusterKey ctrl.ObjectKey) (*tls.Config, error) {
+	ctrlClient := u.K8sClient.CtrlClient()
+
+	etcdCerts := &v1.Secret{}
+	etcdCertsObjectKey := ctrl.ObjectKey{
+		Namespace: clusterKey.Namespace,
+		Name:      fmt.Sprintf("%s-etcd", clusterKey.Name),
+	}
+	if err := ctrlClient.Get(ctx, etcdCertsObjectKey, etcdCerts); err != nil {
+		return nil, microerror.Mask(err)
+	}
+	crtData, ok := etcdCerts.Data[secret.TLSCrtDataName]
+	if !ok {
+		return nil, microerror.Maskf(executionFailedError, "etcd tls crt does not exist for cluster %s/%s", clusterKey.Namespace, clusterKey.Name)
+	}
+	keyData, ok := etcdCerts.Data[secret.TLSKeyDataName]
+	if !ok {
+		return nil, microerror.Maskf(executionFailedError, "etcd tls key does not exist for cluster %s/%s", clusterKey.Namespace, clusterKey.Name)
+	}
+
+	tlsConfig, err := key.PrepareTLSConfig(crtData, crtData, keyData)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return tlsConfig, nil
 }
 
 // Fetch guest cluster ETCD endpoint.
@@ -179,19 +266,19 @@ func (u *Utils) getEtcdEndpoint(ctx context.Context, cluster Cluster) (string, e
 	case awsCAPI:
 		{
 			crd := v1alpha3.AWSCluster{}
-			err := crdClient.Get(ctx, client.ObjectKey{Name: cluster.clusterID, Namespace: cluster.clusterNamespace}, &crd)
+			err := crdClient.Get(ctx, cluster.clusterKey, &crd)
 			if err != nil {
-				return "", microerror.Maskf(executionFailedError, "error getting aws crd for guest cluster %#q with error %#q", cluster.clusterID, err)
+				return "", microerror.Maskf(executionFailedError, "error getting aws crd for guest cluster %#q with error %#q", cluster.clusterKey.Name, err)
 			}
-			etcdEndpoint = AwsCAPIEtcdEndpoint(cluster.clusterID, crd.Spec.Cluster.DNS.Domain)
+			etcdEndpoint = AwsCAPIEtcdEndpoint(cluster.clusterKey.Name, crd.Spec.Cluster.DNS.Domain)
 			break
 		}
 	case azure:
 		{
 			crd := providerv1alpha1.AzureConfig{}
-			err := crdClient.Get(ctx, client.ObjectKey{Name: cluster.clusterID, Namespace: cluster.clusterNamespace}, &crd)
+			err := crdClient.Get(ctx, cluster.clusterKey, &crd)
 			if err != nil {
-				return "", microerror.Maskf(executionFailedError, "error getting azure crd for guest cluster %#q with error %#q", cluster.clusterID, err)
+				return "", microerror.Maskf(executionFailedError, "error getting azure crd for guest cluster %#q with error %#q", cluster.clusterKey.Name, err)
 			}
 			etcdEndpoint = AzureEtcdEndpoint(crd.Spec.Cluster.Etcd.Domain)
 			break
@@ -199,11 +286,40 @@ func (u *Utils) getEtcdEndpoint(ctx context.Context, cluster Cluster) (string, e
 	case kvm:
 		{
 			crd := providerv1alpha1.KVMConfig{}
-			err := crdClient.Get(ctx, client.ObjectKey{Name: cluster.clusterID, Namespace: cluster.clusterNamespace}, &crd)
+			err := crdClient.Get(ctx, cluster.clusterKey, &crd)
 			if err != nil {
-				return "", microerror.Maskf(executionFailedError, "error getting kvm crd for guest cluster %#q with error %#q", cluster.clusterID, err)
+				return "", microerror.Maskf(executionFailedError, "error getting kvm crd for guest cluster %#q with error %#q", cluster.clusterKey.Name, err)
 			}
 			etcdEndpoint = KVMEtcdEndpoint(crd.Spec.Cluster.Etcd.Domain)
+			break
+		}
+	case CAPI:
+		{
+			// for CAPI endpoint we need to fetch workload cluster k8s client and look for controlplane nodes
+			var nodeList v1.NodeList
+
+			targetClusterRESTConfig, err := key.RESTConfig(ctx, crdClient, cluster.clusterKey)
+			if err != nil {
+				return "", microerror.Maskf(executionFailedError, "error fetching CAPI cluster rest config for cluster  %#q with error %#q", cluster.clusterKey.Name, err)
+			}
+
+			targetCtrlClient, err := key.GetCtrlClient(targetClusterRESTConfig)
+			if err != nil {
+				return "", microerror.Maskf(executionFailedError, "error creating CAPI cluster kubernetes client for cluster  %#q with error %#q", cluster.clusterKey.Name, err)
+			}
+
+			err = targetCtrlClient.List(ctx, &nodeList, ctrl.HasLabels{LabelCAPIControlPlaneNode})
+			if err != nil {
+				return "", microerror.Maskf(executionFailedError, "error creating CAPI cluster kubernetes client for cluster  %#q with error %#q", cluster.clusterKey.Name, err)
+			}
+
+			if len(nodeList.Items) == 0 {
+				return "", microerror.Maskf(executionFailedError, "error getting etcd endpoint , no control plane nodes found,  cluster  %#q with error %#q", cluster.clusterKey.Name, err)
+			}
+
+			nodeName := nodeList.Items[0].Name
+
+			etcdEndpoint = CAPIEtcdEndpoint(componentETCD, nodeName)
 			break
 		}
 	}
@@ -212,8 +328,8 @@ func (u *Utils) getEtcdEndpoint(ctx context.Context, cluster Cluster) (string, e
 	return etcdEndpoint, nil
 }
 
-// Fetch all guest clusters IDs in host cluster.
-func (u *Utils) getAllGuestClusters(ctx context.Context, crdCLient client.Client) ([]Cluster, error) {
+// Fetch all workload clusters IDs in host cluster.
+func (u *Utils) getAllWorkloadClusters(ctx context.Context, crdCLient client.Client) ([]Cluster, error) {
 	var clusterList []Cluster
 	anySuccess := false
 
@@ -226,9 +342,11 @@ func (u *Utils) getAllGuestClusters(ctx context.Context, crdCLient client.Client
 			for _, awsClusterObj := range crdList.Items {
 				// Only backup cluster if it was not marked for delete.
 				if awsClusterObj.DeletionTimestamp == nil {
-					clusterList = append(clusterList, Cluster{awsClusterObj.Name, awsClusterObj.Namespace, awsCAPI})
+					clusterList = append(clusterList, Cluster{clusterKey: ctrl.ObjectKey{Name: awsClusterObj.Name, Namespace: awsClusterObj.Namespace}, provider: awsCAPI})
 				}
 			}
+		} else if isMissingCRDError(err) {
+			// ignore missing CRD/KIND error as its expected that single MC do not have all provider CRs
 		} else {
 			u.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Error listing AWSClusters: %s", err))
 		}
@@ -243,9 +361,11 @@ func (u *Utils) getAllGuestClusters(ctx context.Context, crdCLient client.Client
 			for _, azureConfig := range crdList.Items {
 				// Only backup cluster if it was not marked for delete.
 				if azureConfig.DeletionTimestamp == nil {
-					clusterList = append(clusterList, Cluster{azureConfig.Name, azureConfig.Namespace, azure})
+					clusterList = append(clusterList, Cluster{clusterKey: ctrl.ObjectKey{Name: azureConfig.Name, Namespace: azureConfig.Namespace}, provider: azure})
 				}
 			}
+		} else if isMissingCRDError(err) {
+			// ignore missing CRD/KIND error as its expected that single MC do not have all provider CRs
 		} else {
 			u.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Error listing AzureConfigs: %s", err))
 		}
@@ -260,11 +380,31 @@ func (u *Utils) getAllGuestClusters(ctx context.Context, crdCLient client.Client
 			for _, kvmConfig := range crdList.Items {
 				// Only backup cluster if it was not marked for delete.
 				if kvmConfig.DeletionTimestamp == nil {
-					clusterList = append(clusterList, Cluster{kvmConfig.Name, kvmConfig.Namespace, kvm})
+					clusterList = append(clusterList, Cluster{clusterKey: ctrl.ObjectKey{Name: kvmConfig.Name, Namespace: kvmConfig.Namespace}, provider: kvm})
+				}
+			}
+		} else if isMissingCRDError(err) {
+			// ignore missing CRD/KIND error as its expected that single MC do not have all provider CRs
+		} else {
+			u.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Error listing KVMConfigs: %s", err))
+		}
+	}
+
+	// CAPI
+	{
+		crdList := capi.ClusterList{}
+		err := crdCLient.List(ctx, &crdList)
+		if err == nil {
+			anySuccess = true
+			for _, cluster := range crdList.Items {
+				// Only backup cluster if it was not marked for delete.
+				// and if the control and infrastructure is ready
+				if cluster.DeletionTimestamp == nil && cluster.Status.ControlPlaneReady && cluster.Status.InfrastructureReady {
+					clusterList = append(clusterList, Cluster{clusterKey: ctrl.ObjectKey{Name: cluster.Name, Namespace: cluster.Namespace}, provider: CAPI})
 				}
 			}
 		} else {
-			u.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Error listing KVMConfigs: %s", err))
+			u.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Error listing CAPI Clusters: %s", err))
 		}
 	}
 
@@ -294,4 +434,8 @@ func stringVersionCmp(versionStr string, def *semver.Version, reference *semver.
 	}
 
 	return false, nil
+}
+
+func isMissingCRDError(err error) bool {
+	return strings.Contains(err.Error(), "no matches for kind")
 }

--- a/service/controller/etcd_backup.go
+++ b/service/controller/etcd_backup.go
@@ -31,7 +31,6 @@ type ETCDBackup struct {
 }
 
 func validateETCDBackupConfig(config ETCDBackupConfig) error {
-
 	if !config.SkipManagementClusterBackup && !config.ETCDv2Settings.AreComplete() && !config.ETCDv3Settings.AreComplete() {
 		return microerror.Maskf(invalidConfigError, "Either %T.ETCDv2Settings or %T.ETCDv3Settings must be defined", config, config)
 	}
@@ -101,8 +100,6 @@ func newETCDBackupResourceSets(config ETCDBackupConfig) ([]resource.Interface, e
 			Uploader:                    config.Uploader,
 			SkipManagementClusterBackup: config.SkipManagementClusterBackup,
 		}
-		// etcdBackupResourceSetConfig(config)
-
 		resources, err = newETCDBackupResourceSet(c)
 		if err != nil {
 			return nil, microerror.Mask(err)

--- a/service/controller/etcd_backup.go
+++ b/service/controller/etcd_backup.go
@@ -15,14 +15,15 @@ import (
 )
 
 type ETCDBackupConfig struct {
-	K8sClient      k8sclient.Interface
-	Logger         micrologger.Logger
-	ETCDv2Settings giantnetes.ETCDv2Settings
-	ETCDv3Settings giantnetes.ETCDv3Settings
-	EncryptionPwd  string
-	Installation   string
-	SentryDSN      string
-	Uploader       storage.Uploader
+	K8sClient                   k8sclient.Interface
+	Logger                      micrologger.Logger
+	ETCDv2Settings              giantnetes.ETCDv2Settings
+	ETCDv3Settings              giantnetes.ETCDv3Settings
+	EncryptionPwd               string
+	Installation                string
+	SentryDSN                   string
+	Uploader                    storage.Uploader
+	SkipManagementClusterBackup bool
 }
 
 type ETCDBackup struct {
@@ -90,15 +91,16 @@ func newETCDBackupResourceSets(config ETCDBackupConfig) ([]resource.Interface, e
 	var resources []resource.Interface
 	{
 		c := ETCDBackupConfig{
-			K8sClient:      config.K8sClient,
-			Logger:         config.Logger,
-			ETCDv2Settings: config.ETCDv2Settings,
-			ETCDv3Settings: config.ETCDv3Settings,
-			EncryptionPwd:  config.EncryptionPwd,
-			Installation:   config.Installation,
-			Uploader:       config.Uploader,
+			K8sClient:                   config.K8sClient,
+			Logger:                      config.Logger,
+			SkipManagementClusterBackup: config.SkipManagementClusterBackup,
+			ETCDv2Settings:              config.ETCDv2Settings,
+			ETCDv3Settings:              config.ETCDv3Settings,
+			EncryptionPwd:               config.EncryptionPwd,
+			Installation:                config.Installation,
+			Uploader:                    config.Uploader,
 		}
-		//etcdBackupResourceSetConfig(config)
+		// etcdBackupResourceSetConfig(config)
 
 		resources, err = newETCDBackupResourceSet(c)
 		if err != nil {

--- a/service/controller/etcd_backup.go
+++ b/service/controller/etcd_backup.go
@@ -93,12 +93,12 @@ func newETCDBackupResourceSets(config ETCDBackupConfig) ([]resource.Interface, e
 		c := ETCDBackupConfig{
 			K8sClient:                   config.K8sClient,
 			Logger:                      config.Logger,
-			SkipManagementClusterBackup: config.SkipManagementClusterBackup,
 			ETCDv2Settings:              config.ETCDv2Settings,
 			ETCDv3Settings:              config.ETCDv3Settings,
 			EncryptionPwd:               config.EncryptionPwd,
 			Installation:                config.Installation,
 			Uploader:                    config.Uploader,
+			SkipManagementClusterBackup: config.SkipManagementClusterBackup,
 		}
 		// etcdBackupResourceSetConfig(config)
 

--- a/service/controller/etcd_backup.go
+++ b/service/controller/etcd_backup.go
@@ -31,7 +31,8 @@ type ETCDBackup struct {
 }
 
 func validateETCDBackupConfig(config ETCDBackupConfig) error {
-	if !config.ETCDv2Settings.AreComplete() && !config.ETCDv3Settings.AreComplete() {
+
+	if !config.SkipManagementClusterBackup && !config.ETCDv2Settings.AreComplete() && !config.ETCDv3Settings.AreComplete() {
 		return microerror.Maskf(invalidConfigError, "Either %T.ETCDv2Settings or %T.ETCDv3Settings must be defined", config, config)
 	}
 	if config.Installation == "" {

--- a/service/controller/etcd_backup_resource_set.go
+++ b/service/controller/etcd_backup_resource_set.go
@@ -32,13 +32,14 @@ func newETCDBackupResourceSet(config ETCDBackupConfig) ([]resource.Interface, er
 	var etcdBackupResource resource.Interface
 	{
 		c := etcdbackup.Config{
-			K8sClient:      config.K8sClient,
-			Logger:         config.Logger,
-			ETCDv2Settings: config.ETCDv2Settings,
-			ETCDv3Settings: config.ETCDv3Settings,
-			EncryptionPwd:  config.EncryptionPwd,
-			Installation:   config.Installation,
-			Uploader:       config.Uploader,
+			K8sClient:                   config.K8sClient,
+			Logger:                      config.Logger,
+			ETCDv2Settings:              config.ETCDv2Settings,
+			ETCDv3Settings:              config.ETCDv3Settings,
+			EncryptionPwd:               config.EncryptionPwd,
+			Installation:                config.Installation,
+			Uploader:                    config.Uploader,
+			SkipManagementClusterBackup: config.SkipManagementClusterBackup,
 		}
 
 		etcdBackupResource, err = etcdbackup.New(c)

--- a/service/controller/etcd_backup_resource_set.go
+++ b/service/controller/etcd_backup_resource_set.go
@@ -10,7 +10,7 @@ import (
 )
 
 func validateETCDBackupResourceSetConfigConfig(config ETCDBackupConfig) error {
-	if !config.ETCDv2Settings.AreComplete() && !config.ETCDv3Settings.AreComplete() {
+	if !config.SkipManagementClusterBackup && !config.ETCDv2Settings.AreComplete() && !config.ETCDv3Settings.AreComplete() {
 		return microerror.Maskf(invalidConfigError, "Either %T.ETCDv2Settings or %T.ETCDv3Settings must be defined", config, config)
 	}
 	if config.Installation == "" {

--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"errors"
 	"fmt"
 	"io/ioutil"
 
@@ -91,12 +90,12 @@ func TLSConfigFromCertFiles(ca string, cert string, key string) (*tls.Config, er
 func RESTConfig(ctx context.Context, c client.Reader, cluster client.ObjectKey) (*restclient.Config, error) {
 	kubeConfig, err := kcfg.FromSecret(ctx, c, cluster)
 	if err != nil {
-		return nil, errors.New(fmt.Sprintf("failed to retrieve kubeconfig secret for Cluster %s/%s : %s", cluster.Namespace, cluster.Name, err))
+		return nil, microerror.Maskf(executionFailedError, "failed to retrieve kubeconfig secret for Cluster %s/%s : %s", cluster.Namespace, cluster.Name, err)
 	}
 
 	restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeConfig)
 	if err != nil {
-		return nil, errors.New(fmt.Sprintf("failed to create REST configuration for Cluster %s/%s : %s", cluster.Namespace, cluster.Name, err))
+		return nil, microerror.Maskf(executionFailedError, "failed to create REST configuration for Cluster %s/%s : %s", cluster.Namespace, cluster.Name, err)
 	}
 
 	return restConfig, nil

--- a/service/controller/resource/etcdbackup/create_running_v3.go
+++ b/service/controller/resource/etcdbackup/create_running_v3.go
@@ -47,7 +47,7 @@ func (r *Resource) doV3Backup(ctx context.Context, etcdInstance giantnetes.ETCDI
 	if etcdSettings.AreComplete() {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Starting v3 backup on instance %s", instanceStatus.Name))
 
-		backupper, err := etcd.NewV3Backup(etcdSettings.TLSConfig, r.encryptionPwd, etcdSettings.Endpoints, r.logger, key.FilenamePrefix(r.installation, instanceStatus.Name))
+		backupper, err := etcd.NewV3Backup(etcdSettings.TLSConfig, etcdSettings.Proxy, r.encryptionPwd, etcdSettings.Endpoints, r.logger, key.FilenamePrefix(r.installation, instanceStatus.Name))
 		if err != nil {
 			r.logger.LogCtx(ctx, "level", "error", "message", fmt.Sprintf("Failed to repare v3 backup instance %s", instanceStatus.Name))
 			return false

--- a/service/controller/resource/etcdbackup/instances.go
+++ b/service/controller/resource/etcdbackup/instances.go
@@ -34,7 +34,7 @@ func (r *Resource) runBackupOnAllInstances(ctx context.Context, obj interface{},
 
 		// User specified a list of cluster IDs to be backed up.
 		// Load workload clusters.
-		guestInstances, err := utils.GetTenantClusters(ctx, customObject)
+		guestInstances, err := utils.GetTenantClusters(ctx)
 		if err != nil {
 			return false, microerror.Mask(err)
 		}
@@ -84,7 +84,7 @@ func (r *Resource) runBackupOnAllInstances(ctx context.Context, obj interface{},
 
 		if customObject.Spec.GuestBackup {
 			// Tenant clusters.
-			guestInstances, err := utils.GetTenantClusters(ctx, customObject)
+			guestInstances, err := utils.GetTenantClusters(ctx)
 			if err != nil {
 				return false, microerror.Mask(err)
 			}

--- a/service/controller/resource/etcdbackup/instances.go
+++ b/service/controller/resource/etcdbackup/instances.go
@@ -74,12 +74,15 @@ func (r *Resource) runBackupOnAllInstances(ctx context.Context, obj interface{},
 	} else {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "CR does not contain explicit list of cluster names")
 		// Control plane.
-		instances = []giantnetes.ETCDInstance{
-			{
+		var instances []giantnetes.ETCDInstance
+
+		if !r.skipManagementClusterBackup {
+			cp := giantnetes.ETCDInstance{
 				Name:   key.ManagementCluster,
 				ETCDv2: r.etcdV2Settings,
 				ETCDv3: r.etcdV3Settings,
-			},
+			}
+			instances = append(instances, cp)
 		}
 
 		if customObject.Spec.GuestBackup {

--- a/service/controller/resource/etcdbackup/instances.go
+++ b/service/controller/resource/etcdbackup/instances.go
@@ -74,8 +74,6 @@ func (r *Resource) runBackupOnAllInstances(ctx context.Context, obj interface{},
 	} else {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "CR does not contain explicit list of cluster names")
 		// Control plane.
-		var instances []giantnetes.ETCDInstance
-
 		if !r.skipManagementClusterBackup {
 			cp := giantnetes.ETCDInstance{
 				Name:   key.ManagementCluster,

--- a/service/controller/resource/etcdbackup/resource.go
+++ b/service/controller/resource/etcdbackup/resource.go
@@ -45,7 +45,7 @@ func New(config Config) (*Resource, error) {
 	if config.K8sClient == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.k8sClient must not be empty", config)
 	}
-	if !config.ETCDv2Settings.AreComplete() && !config.ETCDv3Settings.AreComplete() {
+	if !config.SkipManagementClusterBackup && !config.ETCDv2Settings.AreComplete() && !config.ETCDv3Settings.AreComplete() {
 		return nil, microerror.Maskf(invalidConfigError, "Either %T.ETCDv2Settings or %T.ETCDv3Settings must be defined", config, config)
 	}
 	if config.Installation == "" {

--- a/service/controller/resource/etcdbackup/resource.go
+++ b/service/controller/resource/etcdbackup/resource.go
@@ -15,24 +15,27 @@ const (
 )
 
 type Config struct {
-	K8sClient      k8sclient.Interface
-	Logger         micrologger.Logger
-	ETCDv2Settings giantnetes.ETCDv2Settings
-	ETCDv3Settings giantnetes.ETCDv3Settings
-	EncryptionPwd  string
-	Installation   string
-	Uploader       storage.Uploader
+	K8sClient                   k8sclient.Interface
+	Logger                      micrologger.Logger
+	ETCDv2Settings              giantnetes.ETCDv2Settings
+	ETCDv3Settings              giantnetes.ETCDv3Settings
+	EncryptionPwd               string
+	Installation                string
+	Uploader                    storage.Uploader
+	SkipManagementClusterBackup bool
 }
 
 type Resource struct {
-	logger         micrologger.Logger
-	k8sClient      k8sclient.Interface
-	stateMachine   state.Machine
-	etcdV2Settings giantnetes.ETCDv2Settings
-	etcdV3Settings giantnetes.ETCDv3Settings
-	encryptionPwd  string
-	installation   string
-	uploader       storage.Uploader
+	logger       micrologger.Logger
+	k8sClient    k8sclient.Interface
+	stateMachine state.Machine
+
+	etcdV2Settings              giantnetes.ETCDv2Settings
+	etcdV3Settings              giantnetes.ETCDv3Settings
+	encryptionPwd               string
+	installation                string
+	uploader                    storage.Uploader
+	skipManagementClusterBackup bool
 }
 
 func New(config Config) (*Resource, error) {
@@ -53,13 +56,14 @@ func New(config Config) (*Resource, error) {
 	}
 
 	r := &Resource{
-		logger:         config.Logger,
-		k8sClient:      config.K8sClient,
-		etcdV2Settings: config.ETCDv2Settings,
-		etcdV3Settings: config.ETCDv3Settings,
-		encryptionPwd:  config.EncryptionPwd,
-		installation:   config.Installation,
-		uploader:       config.Uploader,
+		logger:                      config.Logger,
+		k8sClient:                   config.K8sClient,
+		etcdV2Settings:              config.ETCDv2Settings,
+		etcdV3Settings:              config.ETCDv3Settings,
+		encryptionPwd:               config.EncryptionPwd,
+		installation:                config.Installation,
+		uploader:                    config.Uploader,
+		skipManagementClusterBackup: config.SkipManagementClusterBackup,
 	}
 
 	r.configureStateMachine()

--- a/service/service.go
+++ b/service/service.go
@@ -5,6 +5,7 @@ package service
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"os"
 	"sync"
 
@@ -148,11 +149,11 @@ func New(config Config) (*Service, error) {
 			return nil, microerror.Mask(err)
 		}
 
-		skipMCBackup := true // config.Viper.GetBool(config.Flag.Service.SkipManagementClusterBackup)
-		// fmt.Printf("\n\nloaded viper config skipMCBackup %t\n\n", skipMCBackup)
+		skipMCBackup := config.Viper.GetBool(config.Flag.Service.SkipManagementClusterBackup)
+		fmt.Printf("\n\nloaded viper config skipMCBackup %t\n\n", skipMCBackup)
 
 		var tlsConfig *tls.Config = nil
-		/*if !skipMCBackup {
+		if !skipMCBackup {
 			tlsConfig, err = key.TLSConfigFromCertFiles(
 				config.Viper.GetString(config.Flag.Service.ETCDv3.CaCert),
 				config.Viper.GetString(config.Flag.Service.ETCDv3.Cert),
@@ -161,7 +162,7 @@ func New(config Config) (*Service, error) {
 			if err != nil {
 				return nil, microerror.Mask(err)
 			}
-		}*/
+		}
 
 		c := controller.ETCDBackupConfig{
 			K8sClient: k8sClient,

--- a/service/service.go
+++ b/service/service.go
@@ -150,7 +150,7 @@ func New(config Config) (*Service, error) {
 		}
 
 		skipMCBackup := config.Viper.GetBool(config.Flag.Service.SkipManagementClusterBackup)
-		fmt.Printf("loaded viper config skipMCBackup %t", skipMCBackup)
+		fmt.Printf("\n\nloaded viper config skipMCBackup %t\n\n", skipMCBackup)
 
 		var tlsConfig *tls.Config = nil
 		if !skipMCBackup {

--- a/service/service.go
+++ b/service/service.go
@@ -5,7 +5,6 @@ package service
 import (
 	"context"
 	"crypto/tls"
-	"fmt"
 	"os"
 	"sync"
 
@@ -149,11 +148,11 @@ func New(config Config) (*Service, error) {
 			return nil, microerror.Mask(err)
 		}
 
-		skipMCBackup := config.Viper.GetBool(config.Flag.Service.SkipManagementClusterBackup)
-		fmt.Printf("\n\nloaded viper config skipMCBackup %t\n\n", skipMCBackup)
+		skipMCBackup := true // config.Viper.GetBool(config.Flag.Service.SkipManagementClusterBackup)
+		// fmt.Printf("\n\nloaded viper config skipMCBackup %t\n\n", skipMCBackup)
 
 		var tlsConfig *tls.Config = nil
-		if !skipMCBackup {
+		/*if !skipMCBackup {
 			tlsConfig, err = key.TLSConfigFromCertFiles(
 				config.Viper.GetString(config.Flag.Service.ETCDv3.CaCert),
 				config.Viper.GetString(config.Flag.Service.ETCDv3.Cert),
@@ -162,7 +161,7 @@ func New(config Config) (*Service, error) {
 			if err != nil {
 				return nil, microerror.Mask(err)
 			}
-		}
+		}*/
 
 		c := controller.ETCDBackupConfig{
 			K8sClient: k8sClient,

--- a/service/service.go
+++ b/service/service.go
@@ -4,6 +4,7 @@ package service
 
 import (
 	"context"
+	"crypto/tls"
 	"os"
 	"sync"
 
@@ -147,13 +148,18 @@ func New(config Config) (*Service, error) {
 			return nil, microerror.Mask(err)
 		}
 
-		tlsConfig, err := key.TLSConfigFromCertFiles(
-			config.Viper.GetString(config.Flag.Service.ETCDv3.CaCert),
-			config.Viper.GetString(config.Flag.Service.ETCDv3.Cert),
-			config.Viper.GetString(config.Flag.Service.ETCDv3.Key),
-		)
-		if err != nil {
-			return nil, microerror.Mask(err)
+		skipMCBackup := config.Viper.GetBool(config.Flag.Service.SkipManagementClusterBackup)
+
+		var tlsConfig *tls.Config = nil
+		if !skipMCBackup {
+			tlsConfig, err = key.TLSConfigFromCertFiles(
+				config.Viper.GetString(config.Flag.Service.ETCDv3.CaCert),
+				config.Viper.GetString(config.Flag.Service.ETCDv3.Cert),
+				config.Viper.GetString(config.Flag.Service.ETCDv3.Key),
+			)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
 		}
 
 		c := controller.ETCDBackupConfig{
@@ -166,10 +172,11 @@ func New(config Config) (*Service, error) {
 				Endpoints: config.Viper.GetString(config.Flag.Service.ETCDv3.Endpoints),
 				TLSConfig: tlsConfig,
 			},
-			EncryptionPwd: os.Getenv(key.EncryptionPassword),
-			Installation:  config.Viper.GetString(config.Flag.Service.Installation),
-			SentryDSN:     config.Viper.GetString(config.Flag.Service.Sentry.DSN),
-			Uploader:      uploader,
+			EncryptionPwd:               os.Getenv(key.EncryptionPassword),
+			Installation:                config.Viper.GetString(config.Flag.Service.Installation),
+			SentryDSN:                   config.Viper.GetString(config.Flag.Service.Sentry.DSN),
+			SkipManagementClusterBackup: skipMCBackup,
+			Uploader:                    uploader,
 		}
 
 		etcdBackupController, err = controller.NewETCDBackup(c)

--- a/service/service.go
+++ b/service/service.go
@@ -5,6 +5,7 @@ package service
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"os"
 	"sync"
 
@@ -149,6 +150,7 @@ func New(config Config) (*Service, error) {
 		}
 
 		skipMCBackup := config.Viper.GetBool(config.Flag.Service.SkipManagementClusterBackup)
+		fmt.Printf("loaded viper config skipMCBackup %t", skipMCBackup)
 
 		var tlsConfig *tls.Config = nil
 		if !skipMCBackup {

--- a/service/service.go
+++ b/service/service.go
@@ -5,7 +5,6 @@ package service
 import (
 	"context"
 	"crypto/tls"
-	"fmt"
 	"os"
 	"sync"
 
@@ -150,7 +149,6 @@ func New(config Config) (*Service, error) {
 		}
 
 		skipMCBackup := config.Viper.GetBool(config.Flag.Service.SkipManagementClusterBackup)
-		fmt.Printf("\n\nloaded viper config skipMCBackup %t\n\n", skipMCBackup)
 
 		var tlsConfig *tls.Config = nil
 		if !skipMCBackup {

--- a/service/service.go
+++ b/service/service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/viper"
 	"k8s.io/client-go/rest"
+	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 
 	"github.com/giantswarm/etcd-backup-operator/v3/flag"
 	"github.com/giantswarm/etcd-backup-operator/v3/pkg/giantnetes"
@@ -123,6 +124,7 @@ func New(config Config) (*Service, error) {
 				backupv1alpha1.AddToScheme,
 				infrastructurev1alpha3.AddToScheme,
 				providerv1alpha1.AddToScheme,
+				capi.AddToScheme,
 			},
 			RestConfig: restConfig,
 		}


### PR DESCRIPTION
implement etcd backups for generic CAPI cluster using Kubernetes proxy port forwarding

`pkg/etcd/proxy` code is copied from the cluster-api control plane controller, unfortunately, its under an internal package and it cannot be imported co its  just copy-paste
