### PR TITLE
make etcd-backup-operator k8s 1.24 compatible

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,7 +1,8 @@
 # Consul - no fix yet
-CVE-2022-29153 until=2022-11-01
-CVE-2022-24687 until=2022-11-01
-CVE-2021-23772 until=2022-11-01
-sonatype-2022-0204 until=2022-10-01
-sonatype-2021-1485 until=2022-10-01
-sonatype-2021-0276 until=2022-12-01
+CVE-2022-29153 until=2023-02-01
+CVE-2022-24687 until=2023-02-01
+CVE-2021-23772 until=2023-02-01
+CVE-2021-41803 until=2023-02-01
+sonatype-2022-0204 until=2023-02-01
+sonatype-2021-1485 until=2023-02-01
+sonatype-2021-0276 until=2023-02-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `etcd-backup-operator` is now compatible with Kubernetes Versions >= `v1.24`
+
 ## [4.0.0] - 2022-09-20
 
 ### Added

--- a/helm/etcd-backup-operator/templates/deployment.yaml
+++ b/helm/etcd-backup-operator/templates/deployment.yaml
@@ -26,7 +26,13 @@ spec:
         # Tolerate master taint
         - key: node-role.kubernetes.io/master
           operator: Exists
+          effect: NoSchedule      
+{{- if semverCompare ">=1.24-0" .Capabilities.KubeVersion.GitVersion }}
+        # Tolerate control-plane taint
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
           effect: NoSchedule
+{{- end }}
         # Container creates etcd backups.
         # Run container in host network mode on G8s masters
         # to be able to use 127.0.0.1 as etcd address.
@@ -34,7 +40,11 @@ spec:
         # to etcd data directory. To achive that,
         # mount /var/lib/etcd3 as a volume.
       nodeSelector:
+{{- if semverCompare ">=1.24-0" .Capabilities.KubeVersion.GitVersion }}
+        node-role.kubernetes.io/control-plane: ""
+{{- else }}
         node-role.kubernetes.io/master: ""
+{{- end }}
       volumes:
       - name: {{ include "name" . }}-configmap
         configMap:


### PR DESCRIPTION
as some taints and node-lables has changed in k8s 1.24, it's necessary to adjust the control-plane/master taints

Taints on a `1.24` control-plane node:

```
node-role.kubernetes.io/control-plane:NoSchedule
node-role.kubernetes.io/master:NoSchedule  
```

Labels on a `1.24` control-plane node:

```
node-role.kubernetes.io/control-plane=
```