### PR TITLE
Mark backup failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Correctly mark a backup task as failed when etcd client can't be initialized.
+
 ## [4.2.0] - 2023-01-17
 
 ### Changed

--- a/service/controller/resource/etcdbackup/create_running_v3.go
+++ b/service/controller/resource/etcdbackup/create_running_v3.go
@@ -52,7 +52,7 @@ func (r *Resource) doV3Backup(ctx context.Context, etcdInstance giantnetes.ETCDI
 			r.logger.LogCtx(ctx, "level", "error", "message", fmt.Sprintf("Failed to prepare v3 backup instance %s", instanceStatus.Name), "reason", microerror.Pretty(err, true))
 			instanceStatus.V3.LatestError = err.Error()
 			instanceStatus.V3.Status = instanceBackupStateFailed
-			return false
+			return true
 		}
 
 		backupAttemptResult, err := r.performBackup(ctx, backupper, instanceStatus.Name)

--- a/service/controller/resource/etcdbackup/create_running_v3.go
+++ b/service/controller/resource/etcdbackup/create_running_v3.go
@@ -49,7 +49,9 @@ func (r *Resource) doV3Backup(ctx context.Context, etcdInstance giantnetes.ETCDI
 
 		backupper, err := etcd.NewV3Backup(etcdSettings.TLSConfig, etcdSettings.Proxy, r.encryptionPwd, etcdSettings.Endpoints, r.logger, key.FilenamePrefix(r.installation, instanceStatus.Name))
 		if err != nil {
-			r.logger.LogCtx(ctx, "level", "error", "message", fmt.Sprintf("Failed to repare v3 backup instance %s", instanceStatus.Name), "reason", microerror.Pretty(err, true))
+			r.logger.LogCtx(ctx, "level", "error", "message", fmt.Sprintf("Failed to prepare v3 backup instance %s", instanceStatus.Name), "reason", microerror.Pretty(err, true))
+			instanceStatus.V3.LatestError = err.Error()
+			instanceStatus.V3.Status = instanceBackupStateFailed
 			return false
 		}
 


### PR DESCRIPTION
Correctly mark backups as failed when one of the v3 processes fails