### PR TITLE
Check domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Correctly mark a backup task as failed when etcd client can't be initialized.
+- Check cluster domain is set or fail backup early.
 
 ## [4.2.0] - 2023-01-17
 

--- a/pkg/giantnetes/utils.go
+++ b/pkg/giantnetes/utils.go
@@ -267,7 +267,7 @@ func (u *Utils) getEtcdEndpoint(ctx context.Context, cluster Cluster) (string, e
 				return "", microerror.Maskf(executionFailedError, "error getting aws crd for guest cluster %#q with error %#q", cluster.clusterKey.Name, err)
 			}
 			if crd.Spec.Cluster.DNS.Domain == "" {
-				return "", microerror.Maskf(executionFailedError, "awscluster %#q does not have and cluster domain set in spec.cluster.dns.domain", cluster.clusterKey.Name)
+				return "", microerror.Maskf(executionFailedError, "awscluster %#q does not have any cluster domain set in spec.cluster.dns.domain", cluster.clusterKey.Name)
 			}
 			etcdEndpoint = AwsCAPIEtcdEndpoint(cluster.clusterKey.Name, crd.Spec.Cluster.DNS.Domain)
 			break

--- a/pkg/giantnetes/utils.go
+++ b/pkg/giantnetes/utils.go
@@ -266,6 +266,9 @@ func (u *Utils) getEtcdEndpoint(ctx context.Context, cluster Cluster) (string, e
 			if err != nil {
 				return "", microerror.Maskf(executionFailedError, "error getting aws crd for guest cluster %#q with error %#q", cluster.clusterKey.Name, err)
 			}
+			if crd.Spec.Cluster.DNS.Domain == "" {
+				return "", microerror.Maskf(executionFailedError, "awscluster %#q does not have and cluster domain set in spec.cluster.dns.domain", cluster.clusterKey.Name)
+			}
 			etcdEndpoint = AwsCAPIEtcdEndpoint(cluster.clusterKey.Name, crd.Spec.Cluster.DNS.Domain)
 			break
 		}

--- a/service/controller/resource/etcdbackup/instances.go
+++ b/service/controller/resource/etcdbackup/instances.go
@@ -60,7 +60,7 @@ func (r *Resource) runBackupOnAllInstances(ctx context.Context, obj interface{},
 				if !found {
 					r.logger.LogCtx(ctx, "level", "error", "message", fmt.Sprintf("cluster %q was not found", id))
 					instanceStatus := r.findOrInitializeInstanceStatus(ctx, customObject, id)
-					instanceStatus.Error = "No cluster found with such name"
+					instanceStatus.Error = "No cluster found with such name or unable to initialize etcd client due to missing data. Please check etcd-backup-operator logs for more details."
 					instanceStatus.V2 = nil
 					instanceStatus.V3 = nil
 					customObject.Status.Instances[id] = instanceStatus


### PR DESCRIPTION
if the dns domain for the cluster is missing from awscluster, etcd backup fails.
This PR wants to expose such info in order to ease troubleshooting in this scenario.

When this happens, now the CR ends up like this:

```
apiVersion: backup.giantswarm.io/v1alpha1
kind: ETCDBackup
metadata:
  ...
spec:
  clusterNames:
  - s2nd0
  guestBackup: false
status:
  finishedTimestamp: "2023-01-17T13:34:06Z"
  instances:
    s2nd0:
      error: No cluster found with such name or unable to initialize etcd client due
        to missing data. Please check etcd-backup-operator logs for more details.
      name: s2nd0
  startedTimestamp: "2023-01-17T13:33:53Z"
  status: Failed
```

And in the logs:

```
E 01/17 13:34:03 /opsctl-20230117-143352 etcd-backup | etcd-backup-operator/v4/pkg/giantnetes/utils.go:90 | controller=etcd-backup-operator-etcd-backup-controller | event=update | loop=37 | msg=Failed to fetch etcd endpoint for cluster s2nd0 | reason=map[annotation:awscluster `s2nd0` does not have any cluster domain set in spec.cluster.dns.domain kind:executionFailedError stack:[map[file:/root/project/pkg/giantnetes/utils.go line:270]]] | version=646993372
```

Would be best to have the final error message in the CR, I know, but this is a much bigger refactoring effort that I'd like to avoid