### PR TITLE
set etcdBackupPassphrase in chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added the use of the runtime/default seccomp profile.
-- Added option to set `etcdBackupPassphrase` which enables encryption of the backup.
+- Added option to set `etcdBackupEncryptionPassword` which enables encryption of the backup.
 
 ## [4.2.1] - 2023-01-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added the use of the runtime/default seccomp profile.
+- Added option to set `etcdBackupPassphrase` which enables encryption of the backup.
 
 ## [4.2.1] - 2023-01-17
 

--- a/helm/etcd-backup-operator/templates/deployment.yaml
+++ b/helm/etcd-backup-operator/templates/deployment.yaml
@@ -91,11 +91,11 @@ spec:
               secretKeyRef:
                 name: {{ include "resource.default.name" . }}
                 key: ETCDBACKUP_AWS_SECRET_KEY
-          - name: ETCDBACKUP_PASSPHRASE
+          - name: ENCRYPTION_PASSWORD
             valueFrom:
               secretKeyRef:
                 name: {{ include "resource.default.name" . }}
-                key: ETCDBACKUP_PASSPHRASE
+                key: ETCDBACKUP_ENCRYPTION_PASSWORD
         livenessProbe:
           httpGet:
             path: /healthz

--- a/helm/etcd-backup-operator/templates/secret.yaml
+++ b/helm/etcd-backup-operator/templates/secret.yaml
@@ -9,4 +9,4 @@ type: Opaque
 data:
   ETCDBACKUP_AWS_ACCESS_KEY: {{ .Values.aws.credentials.awsAccessKey | b64enc | quote }}
   ETCDBACKUP_AWS_SECRET_KEY: {{ .Values.aws.credentials.awsSecretKey | b64enc | quote }}
-  ETCDBACKUP_PASSPHRASE: ""
+  ETCDBACKUP_PASSPHRASE: {{ .Values.etcdBackupPassphrase | b64enc | quote }}

--- a/helm/etcd-backup-operator/templates/secret.yaml
+++ b/helm/etcd-backup-operator/templates/secret.yaml
@@ -9,4 +9,4 @@ type: Opaque
 data:
   ETCDBACKUP_AWS_ACCESS_KEY: {{ .Values.aws.credentials.awsAccessKey | b64enc | quote }}
   ETCDBACKUP_AWS_SECRET_KEY: {{ .Values.aws.credentials.awsSecretKey | b64enc | quote }}
-  ETCDBACKUP_PASSPHRASE: {{ .Values.etcdBackupPassphrase | b64enc | quote }}
+  ETCDBACKUP_ENCRYPTION_PASSWORD: {{ .Values.etcdBackupEncryptionPassword | b64enc | quote }}

--- a/helm/etcd-backup-operator/values.schema.json
+++ b/helm/etcd-backup-operator/values.schema.json
@@ -168,6 +168,9 @@
                     "type": "boolean"
                 }
             }
+        },
+        "etcdBackupPassphrase": {
+            "type": "string"
         }
     }
 }

--- a/helm/etcd-backup-operator/values.schema.json
+++ b/helm/etcd-backup-operator/values.schema.json
@@ -36,6 +36,9 @@
         "clientKeyFileName": {
             "type": "string"
         },
+        "etcdBackupEncryptionPassword": {
+            "type": "string"
+        },
         "etcdDataDir": {
             "type": "string"
         },
@@ -168,9 +171,6 @@
                     "type": "boolean"
                 }
             }
-        },
-        "etcdBackupEncryptionPassword": {
-            "type": "string"
         }
     }
 }

--- a/helm/etcd-backup-operator/values.schema.json
+++ b/helm/etcd-backup-operator/values.schema.json
@@ -169,7 +169,7 @@
                 }
             }
         },
-        "etcdBackupPassphrase": {
+        "etcdBackupEncryptionPassword": {
             "type": "string"
         }
     }

--- a/helm/etcd-backup-operator/values.yaml
+++ b/helm/etcd-backup-operator/values.yaml
@@ -58,3 +58,6 @@ podSecurityContext:
 securityContext:
   seccompProfile:
     type: RuntimeDefault
+
+# Set a passphrase to enable encryption
+etcdBackupPassphrase: ""

--- a/helm/etcd-backup-operator/values.yaml
+++ b/helm/etcd-backup-operator/values.yaml
@@ -59,5 +59,5 @@ securityContext:
   seccompProfile:
     type: RuntimeDefault
 
-# Set a passphrase to enable encryption
-etcdBackupPassphrase: ""
+# Set a password to enable backup encryption
+etcdBackupEncryptionPassword: ""


### PR DESCRIPTION
PR to allow `ETCDBACKUP_PASSPHRASE` value in secret template to be set from the value `etcdBackupPassphrase`. This should allow for enabling encryption of the backup via the provided passphrase.