### PR TITLE
fix kubernetes version check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Fix kubernetes version check to add toleration for `node-role.kubernetes.io/control-plane`.
+
 ## [4.3.0] - 2023-02-20
 
 ### Added

--- a/helm/etcd-backup-operator/templates/deployment.yaml
+++ b/helm/etcd-backup-operator/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
         - key: node-role.kubernetes.io/master
           operator: Exists
           effect: NoSchedule      
-{{- if semverCompare ">=1.24-0" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">=1.24.0" .Capabilities.KubeVersion.Version }}
         # Tolerate control-plane taint
         - key: node-role.kubernetes.io/control-plane
           operator: Exists

--- a/helm/etcd-backup-operator/templates/deployment.yaml
+++ b/helm/etcd-backup-operator/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
         # to etcd data directory. To achive that,
         # mount /var/lib/etcd3 as a volume.
       nodeSelector:
-{{- if semverCompare ">=1.24-0" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">=1.24.0" .Capabilities.KubeVersion.Version }}
         node-role.kubernetes.io/control-plane: ""
 {{- else }}
         node-role.kubernetes.io/master: ""


### PR DESCRIPTION
got paged by https://giantswarm.app.opsgenie.com/alert/detail/2575feae-2b27-48da-9bb8-2af44d2f5af5-1683104971891/details

etcd-backup-operator's helm chart has a different deployment spec when running in pre-1.24 and after 1.24 but apparently the syntax is wrong.
this made it unschedulable on `grizzly` MC.

this PR fixes the check