### PR TITLE
Add pre-install,pre-upgrade hooks to PolicyExceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Add helm hook annotations to PolicyExceptions CRs.
 - Update `golang.org/x/net` package to `v0.13.0`.
 - Update `google.golang.org/grpc` package to `v1.57.0`.
 

--- a/helm/etcd-backup-operator/templates/pss-exceptions.yaml
+++ b/helm/etcd-backup-operator/templates/pss-exceptions.yaml
@@ -1,6 +1,8 @@
 apiVersion: kyverno.io/v2alpha1
 kind: PolicyException
 metadata:
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
   name: {{ include "resource.default.name" . }}-exceptions
   namespace: {{ include "resource.default.namespace" . }}
 spec:


### PR DESCRIPTION
The PolicyException has to be created before other manifests. Otherwise, kyverno blocks installation.

The issue can be observed in CAPV MC `gcapeverde`. 