### PR TITLE
Opt-out PSP for 1.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Opt-out PSP for Kubernetes v1.25.
+
 ## [4.5.0] - 2024-01-16
 
 ### Changed

--- a/helm/etcd-backup-operator/templates/psp.yaml
+++ b/helm/etcd-backup-operator/templates/psp.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.global.podSecurityStandards.enforced }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -29,3 +30,4 @@ spec:
   hostNetwork: true
   hostIPC: false
   hostPID: false
+{{- end }}

--- a/helm/etcd-backup-operator/templates/rbac.yaml
+++ b/helm/etcd-backup-operator/templates/rbac.yaml
@@ -69,6 +69,7 @@ roleRef:
   kind: ClusterRole
   name: {{ include "resource.default.name" . }}
   apiGroup: rbac.authorization.k8s.io
+{{- if not .Values.global.podSecurityStandards.enforced }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -100,3 +101,4 @@ roleRef:
   kind: ClusterRole
   name: {{ include "resource.psp.name" . }}
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/helm/etcd-backup-operator/values.schema.json
+++ b/helm/etcd-backup-operator/values.schema.json
@@ -45,6 +45,19 @@
         "etcdEndpoints": {
             "type": "string"
         },
+        "global": {
+            "type": "object",
+            "properties": {
+                "podSecurityStandards": {
+                    "type": "object",
+                    "properties": {
+                        "enforced": {
+                            "type": "boolean"
+                        }
+                    }
+                }
+            }
+        },
         "image": {
             "type": "object",
             "properties": {
@@ -144,15 +157,7 @@
                     "type": "boolean",
                     "default": false
                 },
-                "seccompProfile": {
-                    "type": "object",
-                    "properties": {
-                        "type": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "capabilities":{
+                "capabilities": {
                     "type": "object",
                     "properties": {
                         "drop": {
@@ -161,6 +166,14 @@
                                 "type": "string"
                             },
                             "default": ["ALL"]
+                        }
+                    }
+                },
+                "seccompProfile": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string"
                         }
                     }
                 }

--- a/helm/etcd-backup-operator/values.yaml
+++ b/helm/etcd-backup-operator/values.yaml
@@ -65,3 +65,7 @@ securityContext:
 
 # Set a password to enable backup encryption
 etcdBackupEncryptionPassword: ""
+
+global:
+  podSecurityStandards:
+    enforced: false


### PR DESCRIPTION
We need to ensure PSP gets dropped if we upgrade to 1.25.

Towards: https://github.com/giantswarm/roadmap/issues/2970#issuecomment-1895319718