### PR TITLE
Support skipping backup of Vintage AWS clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support skipping backup of Vintage AWS clusters by adding the annotation `giantswarm.io/etcd-backup-operator-skip-backup=true` to the `AWSCluster` object. This can be used for clusters which got migrated to CAPI.
+
 ### Changed
 
 - Remove deprecated packages and grpc DialOption.


### PR DESCRIPTION
CAPA-migrated workload clusters aren't reachable anymore through their old etcd endpoint, so they must be skipped. They will instead be backed up by their new CAPA MC (instead of the vintage MC from which they were migrated).