### PR TITLE
Ensure default exclude doesn't match any clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Ensure the default `clustersToExcludeRegex` doesn't match any clusters
+
 ## [4.10.0] - 2025-02-27
 
 ### Added

--- a/create-cr.sh
+++ b/create-cr.sh
@@ -3,7 +3,7 @@
 name="etcd-backup-$(date "+%Y%m%d%H%M%S")"
 guest_backup="${1}"
 clusters_regex="${2:-.*}"
-clusters_to_exclude_regex="${3:-.*}"
+clusters_to_exclude_regex="${3:-^$}"
 
 # Check guest backup.
 if [ "${guest_backup}" != "true" ] && [ "${guest_backup}" != "false" ]


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/32874

Makes sure that the default value for `clustersToExcludeRegex` is `^$` which will not match any cluster names.