### PR TITLE
Add BackupDestination label to support multiple operator instances

### DIFF
--- a/create-cr.sh
+++ b/create-cr.sh
@@ -4,12 +4,13 @@ name="etcd-backup-$(date "+%Y%m%d%H%M%S")"
 guest_backup="${1}"
 clusters_regex="${2:-.*}"
 clusters_to_exclude_regex="${3:-^$}"
+destination="${4:-primary}" # Add destination parameter, default to "primary"
 
 # Check guest backup.
 if [ "${guest_backup}" != "true" ] && [ "${guest_backup}" != "false" ]
 then
   # Print usage.
-  echo "Usage: ${0} <true|false> [clusters_regex] [clusters_to_exclude_regex]"
+  echo "Usage: ${0} <true|false> [clusters_regex] [clusters_to_exclude_regex] [destination]"
   # Exit erroneously.
   exit 1
 fi
@@ -20,6 +21,8 @@ apiVersion: backup.giantswarm.io/v1alpha1
 kind: ETCDBackup
 metadata:
   name: ${name}
+  labels:
+    backup.giantswarm.io/destination: ${destination}
 spec:
   guestBackup: ${guest_backup}
   clustersRegex: "${clusters_regex}"

--- a/flag/service/service.go
+++ b/flag/service/service.go
@@ -13,4 +13,5 @@ type Service struct {
 	ETCDv3                      ETCDv3Settings
 	Installation                string
 	Sentry                      Sentry
+	BackupDestination           string
 }

--- a/helm/etcd-backup-operator/templates/configmap.yaml
+++ b/helm/etcd-backup-operator/templates/configmap.yaml
@@ -14,6 +14,7 @@ data:
       listen:
         address: "http://0.0.0.0:{{ .Values.service.port }}"
     service:
+      backupDestination: "{{ .Values.backupDestination }}"
       kubernetes:
         address: ''
         inCluster: true

--- a/helm/etcd-backup-operator/templates/cronjob.yaml
+++ b/helm/etcd-backup-operator/templates/cronjob.yaml
@@ -27,6 +27,8 @@ spec:
             - {{ $schedule.clusters | quote }}
             {{- if $schedule.clusters_to_exclude }}
             - {{ $schedule.clusters_to_exclude | quote }}
+            {{- else }}
+            - "^$"  # Default empty regex when not specified
             {{- end }}
             - {{ $.Values.backupDestination | quote }}
           restartPolicy: Never

--- a/helm/etcd-backup-operator/templates/cronjob.yaml
+++ b/helm/etcd-backup-operator/templates/cronjob.yaml
@@ -28,5 +28,6 @@ spec:
             {{- if $schedule.clusters_to_exclude }}
             - {{ $schedule.clusters_to_exclude | quote }}
             {{- end }}
+            - {{ $.Values.backupDestination | quote }}
           restartPolicy: Never
 {{- end }}

--- a/helm/etcd-backup-operator/values.schema.json
+++ b/helm/etcd-backup-operator/values.schema.json
@@ -24,6 +24,9 @@
                 }
             }
         },
+        "backupDestination": {
+            "type": "string"
+        },
         "clientCaCertFileName": {
             "type": "string"
         },

--- a/helm/etcd-backup-operator/values.yaml
+++ b/helm/etcd-backup-operator/values.yaml
@@ -49,6 +49,9 @@ installation: ""
 verticalPodAutoscaler:
   enabled: true
 
+# Primary backup destination or customer-specific
+backupDestination: "primary"
+
 # priorityClassName used by the pod.
 priorityClassName: "giantswarm-critical"
 

--- a/main.go
+++ b/main.go
@@ -108,6 +108,7 @@ func mainE(ctx context.Context) error {
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.TLS.CrtFile, "", "Certificate file path to use to authenticate with Kubernetes.")
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.TLS.KeyFile, "", "Key file path to use to authenticate with Kubernetes.")
 	daemonCommand.PersistentFlags().Bool(f.Service.SkipManagementClusterBackup, false, "Skip management cluster backup.")
+	daemonCommand.PersistentFlags().String(f.Service.BackupDestination, "", "Backup destination, primarily used for filtering when ETCDBackup CRs are watched when running multiple etcd-backup-operators, distinguishes between GiantSwarm and Customer destinations.")
 	daemonCommand.PersistentFlags().String(f.Service.S3.Bucket, "", "AWS S3 Bucket name.")
 	daemonCommand.PersistentFlags().String(f.Service.S3.Region, "", "AWS S3 Region name.")
 	daemonCommand.PersistentFlags().String(f.Service.S3.Endpoint, "", "Custom AWS S3 Endpoint.")

--- a/main.go
+++ b/main.go
@@ -108,7 +108,7 @@ func mainE(ctx context.Context) error {
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.TLS.CrtFile, "", "Certificate file path to use to authenticate with Kubernetes.")
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.TLS.KeyFile, "", "Key file path to use to authenticate with Kubernetes.")
 	daemonCommand.PersistentFlags().Bool(f.Service.SkipManagementClusterBackup, false, "Skip management cluster backup.")
-	daemonCommand.PersistentFlags().String(f.Service.BackupDestination, "", "Backup destination, primarily used for filtering when ETCDBackup CRs are watched when running multiple etcd-backup-operators, distinguishes between GiantSwarm and Customer destinations.")
+	daemonCommand.PersistentFlags().String(f.Service.BackupDestination, "", "Backup destination, primarily used for filtering when ETCDBackup CRs are watched.")
 	daemonCommand.PersistentFlags().String(f.Service.S3.Bucket, "", "AWS S3 Bucket name.")
 	daemonCommand.PersistentFlags().String(f.Service.S3.Region, "", "AWS S3 Region name.")
 	daemonCommand.PersistentFlags().String(f.Service.S3.Endpoint, "", "Custom AWS S3 Endpoint.")

--- a/main.go
+++ b/main.go
@@ -108,7 +108,7 @@ func mainE(ctx context.Context) error {
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.TLS.CrtFile, "", "Certificate file path to use to authenticate with Kubernetes.")
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.TLS.KeyFile, "", "Key file path to use to authenticate with Kubernetes.")
 	daemonCommand.PersistentFlags().Bool(f.Service.SkipManagementClusterBackup, false, "Skip management cluster backup.")
-	daemonCommand.PersistentFlags().String(f.Service.BackupDestination, "", "Backup destination, primarily used for filtering when ETCDBackup CRs are watched.")
+	daemonCommand.PersistentFlags().String(f.Service.BackupDestination, "", "Backup destination is a filter for the ETCDBackup CRs. This is useful when running multiple instances of the operator in the same cluster.")
 	daemonCommand.PersistentFlags().String(f.Service.S3.Bucket, "", "AWS S3 Bucket name.")
 	daemonCommand.PersistentFlags().String(f.Service.S3.Region, "", "AWS S3 Region name.")
 	daemonCommand.PersistentFlags().String(f.Service.S3.Endpoint, "", "Custom AWS S3 Endpoint.")

--- a/service/service.go
+++ b/service/service.go
@@ -61,6 +61,9 @@ func New(config Config) (*Service, error) {
 	} else {
 		serviceAddress = ""
 	}
+	if config.Viper.GetString(config.Flag.Service.BackupDestination) == "" {
+		return nil, microerror.Maskf(invalidConfigError, "BackupDestination must not be empty.")
+	}
 	if config.Viper.GetString(config.Flag.Service.S3.Bucket) == "" {
 		return nil, microerror.Maskf(invalidConfigError, "S3Uploader bucket must not be empty.")
 	}
@@ -179,6 +182,7 @@ func New(config Config) (*Service, error) {
 			SentryDSN:                   config.Viper.GetString(config.Flag.Service.Sentry.DSN),
 			SkipManagementClusterBackup: skipMCBackup,
 			Uploader:                    uploader,
+			BackupDestination:           config.Viper.GetString(config.Flag.Service.BackupDestination),
 		}
 
 		etcdBackupController, err = controller.NewETCDBackup(c)


### PR DESCRIPTION
## What this PR does

This PR enables running multiple instances of etcd-backup-operator simultaneously in the same cluster without conflicts. Each instance can be configured with different S3 destinations (like different AWS accounts) while operating independently.

Previously, when running multiple instances, they would compete for ETCDBackup CRs, resulting in duplicated processing and potential race conditions. This change allows each operator instance to only process ETCDBackup CRs specifically labeled for it.

## Use case

This specifically addresses customer requirements to store etcd backups in both:
- Giant Swarm's managed S3 bucket (default)
- Customer's own AWS account/S3 bucket (secondary)

With this change, we can deploy:
- Primary operator instance with `backupDestination: "primary"`
- Secondary operator instance with `backupDestination: "customer"`

Each will only process the CRs intended for it, sending backups to different S3 destinations.

## Implementation details

- Added a required `BackupDestination` field in service configuration
- Pass BackupDestination to ETCDBackup controller for filtering CRs
- Use label selectors in controller to watch only relevant CRs
- Modified scheduler jobs to label created CRs with the appropriate destination
- Provide a default empty regex (^$) when clusters_to_exclude isn't specified otherwise it breaks arguments.