### PR TITLE
Fix IRSA authentication in AWS China regions by setting regional STS endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Go: Update dependencies.
 
+### Fixed
+
+- Fix IRSA authentication in AWS China regions by setting regional STS endpoint.
+
 ## [4.13.0] - 2025-05-06
 
 ### Added

--- a/pkg/storage/s3.go
+++ b/pkg/storage/s3.go
@@ -3,9 +3,11 @@ package storage
 import (
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/giantswarm/microerror"
@@ -77,6 +79,13 @@ func (upload S3Upload) Upload(fpath string) (int64, error) {
 	}
 	if upload.forcePathStyle {
 		awsConfig.S3ForcePathStyle = aws.Bool(true)
+	}
+
+	// For China regions, ensure correct partition handling
+	if upload.enableIRSA {
+		if strings.HasPrefix(upload.region, "cn-") {
+			awsConfig.STSRegionalEndpoint = endpoints.RegionalSTSEndpoint
+		}
 	}
 
 	sess, err := session.NewSession(awsConfig)


### PR DESCRIPTION
When using IRSA in AWS China regions (cn-*), the etcd-backup-operator was failing with "No OpenIDConnect provider found" errors. This was caused by the AWS SDK not using the correct regional STS endpoint for China partitions.